### PR TITLE
WIP: Change Transport to allow for implementing partially reliable transport like QUIC

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -2,8 +2,12 @@ use crate::config::TransportConfig;
 use anyhow::Result;
 use async_trait::async_trait;
 use std::fmt::Debug;
+use std::io;
+use std::io::Error;
 use std::net::SocketAddr;
-use tokio::io::{AsyncRead, AsyncWrite};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::ToSocketAddrs;
 
 // Specify a transport layer, like TCP, TLS
@@ -11,15 +15,38 @@ use tokio::net::ToSocketAddrs;
 pub trait Transport: Debug + Send + Sync {
     type Acceptor: Send + Sync;
     type RawStream: Send + Sync;
-    type Stream: 'static + AsyncRead + AsyncWrite + Unpin + Send + Sync + Debug;
+    type ReliableStream: 'static + AsyncRead + AsyncWrite + Unpin + Send + Sync + Debug;
+    type UnreliableStream: 'static + AsyncRead + AsyncWrite + Unpin + Send + Sync + Debug;
+
 
     async fn new(config: &TransportConfig) -> Result<Self>
     where
         Self: Sized;
     async fn bind<T: ToSocketAddrs + Send + Sync>(&self, addr: T) -> Result<Self::Acceptor>;
     async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::RawStream, SocketAddr)>;
-    async fn handshake(&self, conn: Self::RawStream) -> Result<Self::Stream>;
-    async fn connect(&self, addr: &str) -> Result<Self::Stream>;
+
+    /// Perform handshake using a newly initiated raw stream (tcp/udp)
+    /// return a properly configured connection for protocol that transport uses.
+    ///
+    /// The returned connection may either be Reliable or Partially Reliable
+    /// (wholly unreliable transport are not currently supported).
+    ///
+    /// Both Partially reliable and strictly reliable transport must provide a reliable stream
+    /// If partially reliable, then an unreliable stream must additionally be provided
+    async fn handshake(&self, conn: Self::RawStream) -> Result<TransportStream<Self>>;
+
+    /// Connection to Server
+    /// return
+    ///   - A reliable ordered stream used for control channel communication
+    ///   - Optionally an unordered and unreliable stream used for data channel forwarding
+    ///     If no such stream is provided, then data will be sent using the reliable stream.
+    async fn connect(&self, addr: &str) -> Result<TransportStream<Self>>;
+}
+
+#[derive(Debug)]
+pub enum TransportStream<T: Transport + ?Sized> {
+    StrictlyReliable(T::ReliableStream),
+    PartiallyReliable(T::ReliableStream, T::UnreliableStream),
 }
 
 mod tcp;
@@ -33,3 +60,54 @@ pub use tls::TlsTransport;
 mod noise;
 #[cfg(feature = "noise")]
 pub use noise::NoiseTransport;
+
+impl<T> TransportStream<T>
+    where T: Transport
+{
+    pub async fn write_all_reliably<'a>(&'a mut self, src: &'a [u8]) -> std::io::Result<()> {
+        let r = match self {
+            TransportStream::StrictlyReliable(s) => s.write_all(src).await,
+            TransportStream::PartiallyReliable(s, _) => s.write_all(src).await,
+        };
+        r
+    }
+
+    pub(crate) fn get_reliable_stream(&mut self) -> &mut T::ReliableStream
+    {
+        match self {
+            TransportStream::StrictlyReliable(s) => s,
+            TransportStream::PartiallyReliable(s, _) => s,
+        }
+    }
+
+    pub fn into_reliable_stream(self) -> T::ReliableStream {
+        match self {
+            TransportStream::StrictlyReliable(s) => s,
+            TransportStream::PartiallyReliable(s, _) => s,
+        }
+    }
+}
+
+/// A dummy struct for use with transports that are strictly reliable
+#[derive(Debug)]
+pub struct UnimplementedUnreliableStream;
+
+impl AsyncRead for UnimplementedUnreliableStream {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        todo!()
+    }
+}
+
+impl AsyncWrite for UnimplementedUnreliableStream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        todo!()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Error>> {
+        todo!()
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Error>> {
+        todo!()
+    }
+}

--- a/src/transport/quic.rs
+++ b/src/transport/quic.rs
@@ -1,0 +1,319 @@
+use futures::lock::Mutex;
+use std::borrow::{Borrow, BorrowMut};
+use std::fmt::{Debug, Formatter};
+use std::io;
+use std::io::{Error, IoSlice};
+use std::net::SocketAddr;
+use std::ops::Deref;
+use std::ops::DerefMut;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+use std::time::Duration;
+
+use super::Transport;
+use crate::config::{TlsConfig, TransportConfig};
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures_util::{AsyncWriteExt, ready, StreamExt, Stream};
+use openssl::pkcs12::Pkcs12;
+use quinn::{Connection, ConnectionError, Datagrams, Endpoint, EndpointConfig, Incoming, NewConnection, SendDatagramError};
+use rustls::internal::msgs::codec::Codec;
+use rustls::ClientConfig;
+use tokio::fs;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::{ToSocketAddrs, UdpSocket};
+use tokio_native_tls::native_tls::Certificate;
+use crate::transport::TransportStream;
+
+pub const ALPN_QUIC_TUNNEL: &[&[u8]] = &[b"qt"];
+pub const NONE: &str = "None";
+
+pub struct QuicTransport {
+    config: TlsConfig,
+    client_crypto: Option<rustls::ClientConfig>,
+}
+
+impl Debug for QuicTransport {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let client_crypto = &self.client_crypto.as_ref().map(|_| "ClientConfig{}");
+
+        f.debug_struct("QuicTransport")
+            .field("config", &self.config)
+            .field("client_crypto", client_crypto)
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+pub struct QuicBiStream {
+    send: quinn::SendStream,
+    recv: quinn::RecvStream,
+    conn: Connection,
+}
+
+#[derive(Debug)]
+pub struct QuicDatagramStream {
+    conn: Connection,
+    datagrams: Datagrams,
+}
+
+impl QuicBiStream {
+    fn new((mut send, recv): (quinn::SendStream, quinn::RecvStream), conn: Connection) -> Self {
+        Self { send, recv, conn}
+    }
+}
+
+
+impl QuicDatagramStream {
+    fn new(mut datagrams: Datagrams, conn: Connection) -> Self {
+        QuicDatagramStream{
+            datagrams,
+            conn,
+        }
+    }
+}
+
+impl tokio::io::AsyncRead for QuicBiStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        // ready!(AsyncRead::poll_read(self.recv., cx, buf))?;
+        // Poll::Ready(Ok(()))
+        Pin::new(self.get_mut().recv.borrow_mut()).poll_read(cx, buf)
+    }
+}
+
+impl tokio::io::AsyncRead for QuicDatagramStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        match Pin::new(self.get_mut().datagrams.borrow_mut()).poll_next(cx) {
+            Poll::Ready(Some(Ok(b))) => {
+                buf.put_slice(b.as_ref());
+                return Poll::Ready(std::io::Result::Ok(()))
+            }
+            Poll::Ready(Some(Err(err))) => Poll::Ready(std::io::Result::Err(Error::from(std::io::ErrorKind::BrokenPipe))),
+            Poll::Ready(None) =>  Poll::Ready(std::io::Result::Err(Error::from(std::io::ErrorKind::BrokenPipe))),
+            Poll::Pending => {Poll::Pending}
+        }
+    }
+}
+
+impl AsyncWrite for QuicBiStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::result::Result<usize, Error>> {
+        Pin::new(self.get_mut().send.borrow_mut()).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(self.get_mut().send.borrow_mut()).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::result::Result<(), Error>> {
+        Pin::new(self.get_mut().send.borrow_mut()).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<std::result::Result<usize, Error>> {
+        Pin::new(self.get_mut().send.borrow_mut()).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.send.is_write_vectored()
+    }
+}
+
+impl AsyncWrite for QuicDatagramStream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>, buf: &[u8]) -> Poll<std::result::Result<usize, Error>> {
+        match self.conn.send_datagram(Bytes::from(buf)) {
+            Ok(_) => Poll::Ready(Ok(buf.len())),
+            Err(e) => Poll::Ready(std::io::Result::Err(Error::from(std::io::ErrorKind::BrokenPipe))),
+            }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<std::result::Result<(), Error>> {
+        todo!()
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<std::result::Result<(), Error>> {
+        todo!()
+    }
+}
+
+
+pub struct QuicAcceptor(Arc<Mutex<(Endpoint, Incoming)>>);
+
+impl Drop for QuicAcceptor {
+    fn drop(&mut self) {
+        if let Some(guard) = self.0.try_lock() {
+            guard.0.close(0u8.into(), &[])
+        }
+    }
+}
+
+impl Drop for QuicBiStream {
+    fn drop(&mut self) {
+        self.conn.close(0u8.into(), &[]);
+    }
+}
+
+#[async_trait]
+impl Transport for QuicTransport {
+    type Acceptor = QuicAcceptor;
+    type ReliableStream = QuicBiStream;
+    type UnreliableStream = QuicDatagramStream;
+
+    async fn new(config: &TransportConfig) -> Result<Self> {
+        let config = match &config.tls {
+            Some(v) => v,
+            None => {
+                return Err(anyhow!("Missing tls config"));
+            }
+        };
+
+        let client_crypto = match config.trusted_root.as_ref() {
+            Some(path) => {
+                let s = fs::read_to_string(path)
+                    .await
+                    .with_context(|| "Failed to read the `tls.trusted_root`")?;
+                let cert = Certificate::from_pem(s.as_bytes())
+                    .with_context(|| "Failed to read certificate from `tls.trusted_root`")?;
+
+                let mut roots = rustls::RootCertStore::empty();
+
+                roots.add(&rustls::Certificate(
+                    cert.to_der()
+                        .with_context(|| "could not encode trust root as DER")?,
+                ));
+
+                let mut client_crypto = rustls::ClientConfig::builder()
+                    .with_safe_defaults()
+                    .with_root_certificates(roots)
+                    .with_no_client_auth();
+                client_crypto.alpn_protocols = ALPN_QUIC_TUNNEL.iter().map(|&x| x.into()).collect();
+                Some(client_crypto)
+            }
+            None => None,
+        };
+
+        Ok(QuicTransport {
+            config: config.clone(),
+            client_crypto,
+        })
+    }
+
+    async fn bind<A: ToSocketAddrs + Send + Sync>(&self, addr: A) -> Result<Self::Acceptor> {
+        let buf = fs::read(self.config.pkcs12.as_ref().unwrap())
+            .await
+            .with_context(|| "Failed to read the `tls.pkcs12`")?;
+
+        let pkcs12 =
+            Pkcs12::from_der(buf.as_slice()).with_context(|| "Failed to open `tls.pkcs12`")?;
+
+        let parsed = pkcs12
+            .parse(self.config.pkcs12_password.as_ref().unwrap())
+            .with_context(|| "Could not decrypt  `tls.pkcs12` using `tls.pkcs12_password`")?;
+
+        let mut chain: Vec<rustls::Certificate> = parsed
+            .chain
+            .unwrap()
+            .into_iter()
+            .map(|cert| rustls::Certificate(cert.to_der().unwrap()))
+            .rev()
+            .collect();
+        chain.insert(
+            0,
+            rustls::Certificate(
+                parsed
+                    .cert
+                    .to_der()
+                    .with_context(|| "Could not encode server cert as PEM")?,
+            ),
+        );
+
+        let key = rustls::PrivateKey(parsed.pkey.private_key_to_der().unwrap());
+
+        let mut server_crypto = rustls::ServerConfig::builder()
+            .with_safe_defaults()
+            .with_no_client_auth()
+            .with_single_cert(chain, key)
+            .with_context(|| "Server keys invalid")?;
+
+        server_crypto.alpn_protocols = ALPN_QUIC_TUNNEL.iter().map(|&x| x.into()).collect();
+
+        let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(server_crypto));
+        Arc::get_mut(&mut server_config.transport)
+            .unwrap()
+            .datagram_receive_buffer_size(Some(65536))
+            .datagram_send_buffer_size(65536)
+            .max_idle_timeout(Some(Duration::from_secs(10).try_into()?));
+
+        server_config.use_retry(true);
+        let socket = UdpSocket::bind(addr).await?.into_std()?;
+        quinn::Endpoint::new(EndpointConfig::default(), Some(server_config), socket)
+            .with_context(|| "Failed to start server")
+            .map(|e_i| QuicAcceptor(Arc::new(Mutex::new(e_i))))
+    }
+
+    async fn accept(&self, a: &Self::Acceptor) -> Result<(TransportStream<Self>, SocketAddr)> {
+        // let a_guard = a.lock().unwrap();
+        while let Some(connecting) = a.0.lock().await.1.next().await {
+            let addr = connecting.remote_address();
+            let mut conn = connecting.await?;
+            if let Some(stream) = conn.bi_streams.next().await {
+
+                return Ok((TransportStream::PartiallyReliable(
+                    QuicBiStream::new(stream.unwrap(), conn.connection.clone()),
+                    QuicDatagramStream::new(conn.datagrams, conn.connection)
+                ), addr));
+            }
+        }
+        Err(anyhow!("endpoint closed"))
+    }
+
+    async fn connect(&self, addr: &str) -> Result<TransportStream<Self>> {
+        let mut endpoint = quinn::Endpoint::client("[::]:0".parse().unwrap())
+            .with_context(|| "could not open client socket")?;
+        let mut config =
+            quinn::ClientConfig::new(Arc::new(self.client_crypto.as_ref().unwrap().clone()));
+        // server times out afte 10 sec, so send keepalive every 5 sec
+        Arc::get_mut(&mut config.transport)
+            .unwrap()
+            .keep_alive_interval(Some(Duration::from_secs(5).try_into()?))
+            .datagram_receive_buffer_size(Some(65536))
+            .datagram_send_buffer_size(65536);
+        endpoint.set_default_client_config(config);
+        let connecting = endpoint.connect(
+            addr.parse().with_context(|| "server address not valid")?,
+            self.config
+                .hostname
+                .as_ref()
+                .unwrap_or(&String::from(addr.split(':').next().unwrap())),
+        )?;
+        let new_conn = connecting.await?;
+
+        Ok(TransportStream::PartiallyReliable(
+            QuicBiStream::new(new_conn.connection.open_bi().await?, new_conn.connection.clone()),
+            QuicDatagramStream::new(new_conn.datagrams, new_conn.connection),
+        ))
+    }
+}
+

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -127,6 +127,8 @@ async fn test(config_path: &'static str, t: Type) -> Result<()> {
     client_shutdown_tx.send(true)?;
     let _ = tokio::join!(client);
 
+    // Wait for the server connection to be closed (quic)
+    time::sleep(Duration::from_millis(2500)).await;
     info!("restart the client");
     let client_shutdown_rx = client_shutdown_tx.subscribe();
     let client = tokio::spawn(async move {


### PR DESCRIPTION
This PR is meant as a way to discuss how the `Transport` trait could be changed such that protocols that are partially reliable can leverage their ability to send forwarded packets unordered and unreliably.

I will repeat my thought from https://github.com/rapiz1/rathole/pull/64#issuecomment-1008272457
 # Benefits from forwarding packets unordered and unreliably
 An ordered reliable transport, mans that:

 1) **all** packets will be received 
 2) packets will be read in the order they are sent.

Now, this is nice (almost necessary) for the control channel. But it is actually a problem for the data channel.

As an example, retransmission of TCP packets in our "tunnel" will make it seem as if there is 0 loss from point of view of the original sender, which will make it impossible for them to detect congestion. (see TCP-meltdown)

Also, having all packets be ordered will introduce head-of-line blocking in the transport itself. If we are carrying UDP, this unnecessarily chkoes bandwidth. If we are carrying TCP, then we now have 2 layers of HOL blocking, where just one should suffice.

Some protocols, such as QUIC allows us to choose where any packet should be sent reliably, or unreliably. We can use that to simplify control channel and command packet code (no need for manual retransmission etc), whilst having all the forwarded packets be carried by unreliable streams.


The main protocol I envision building atop this PR is QUIC. However, I would like the approch to be useful for a TCP/UDP combination, such as seen in FTP:
 - establish connection over TCP/TLS 
 - Server opens a UDP port for the client to use for forwarding
 - forward packets as encrypted UDP payloads using AES key shared over the TLS connection)

# Approaches
The first approach in this PR is to introduce an `enum TransportStream` that may either contain 1 or 2 streams depending on whether the protocol wishes (is capable) of providing an unreliable stream in addition to the reliable one that is **must** provide.

An alternative would be to define a new "downgrade" method in the `Transport` trait that _consumes_ the reliable stream into an unreliable one. This would likely suffice given that, as soon as we start the actual forwarding, no more commands needs to be sent reliable on the data channel. The control channel will keep needing a reliable connection, but it will simply never downgrade.

Either way, I don't see how to do this without requiring all `Transport` implementers define an `UnreliableStream` type. Unless of course, we just have 1 `Transport::Stream` type can be put into either reliable or unreliable mode. Likely, that would entail some flag or state that must be checked every time a packet is received or sent which may incur a slight amount of unwanted overhead. Yet, it may well be the simplest solution.