### PR TITLE
feat: allow config service only on client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -449,7 +449,7 @@ impl<T: 'static + Transport> ControlChannel<T> {
                     let s = toml::to_string(&self.service).unwrap();
                     let buf = s.as_bytes();
                     conn.write_u32(buf.len() as u32).await?;
-                    conn.write_all(&buf).await?;
+                    conn.write_all(buf).await?;
                     conn.flush().await?;
                 }
                 v => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ pub struct ClientServiceConfig {
     #[serde(skip)]
     pub name: String,
     pub local_addr: String,
+    pub recommend_blind_addr: Option<String>, 
     pub token: Option<MaskedString>,
     pub nodelay: Option<bool>,
     pub retry_interval: Option<u64>,
@@ -214,11 +215,17 @@ fn default_heartbeat_interval() -> u64 {
     DEFAULT_HEARTBEAT_INTERVAL_SECS
 }
 
+fn default_accept_client_recommend_service() -> bool {
+    false
+}
+
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ServerConfig {
     pub bind_addr: String,
     pub default_token: Option<MaskedString>,
+    #[serde(default = "default_accept_client_recommend_service")]
+    pub accept_client_recommend_service: bool,
     pub services: HashMap<String, ServerServiceConfig>,
     #[serde(default)]
     pub transport: TransportConfig,

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,7 +63,7 @@ pub struct ClientServiceConfig {
     #[serde(skip)]
     pub name: String,
     pub local_addr: String,
-    pub recommend_blind_addr: Option<String>, 
+    pub recommend_bind_addr: Option<String>, 
     pub token: Option<MaskedString>,
     pub nodelay: Option<bool>,
     pub retry_interval: Option<u64>,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -116,8 +116,7 @@ impl UdpTraffic {
     }
 
     pub async fn read<T: AsyncRead + Unpin>(reader: &mut T, hdr_len: u8) -> Result<UdpTraffic> {
-        let mut buf = Vec::new();
-        buf.resize(hdr_len as usize, 0);
+        let mut buf = vec![0; hdr_len as usize];
         reader
             .read_exact(&mut buf)
             .await

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,6 +1,6 @@
 pub const HASH_WIDTH_IN_BYTES: usize = 32;
 
-use anyhow::{bail, Context, Result, anyhow};
+use anyhow::{bail, Context, Result};
 use bytes::{Bytes, BytesMut};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -227,9 +227,9 @@ pub async fn read_server_service_config_from_client<T: AsyncRead + AsyncWrite + 
     let config: ClientServiceConfig = toml::from_str(&String::from_utf8(buf)?[..]).with_context(|| "Failed to parse the config")?;
     Ok(
         ServerServiceConfig{
-            bind_addr: match config.recommend_blind_addr {
+            bind_addr: match config.recommend_bind_addr {
                 Some(bind_addr) => bind_addr,
-                None => return Err(anyhow!(format!("Expect 'recommend_blind_addr' in {}", config.name))),
+                None => return Err(anyhow::anyhow!(format!("Expect 'recommend_bind_addr' in {}", config.name))),
             },
             service_type: config.service_type,
             name: config.name,


### PR DESCRIPTION
Related to #161 

允许server直接使用client对service的配置

在server启用
```toml
[server]
accept_client_recommend_service = true

[server.services] #这个东西现在还是必须要有
```

在client配置
```toml
[client.services.echo] 
local_addr = "127.0.0.1:8080" 
recommend_blind_addr = "0.0.0.0:2334"
```
