### PR TITLE
fix: config watcher follow symlinks

### DIFF
--- a/src/config_watcher.rs
+++ b/src/config_watcher.rs
@@ -162,7 +162,7 @@ async fn config_watcher(
             Err(e) => error!("watch error: {:#}", e),
         })?;
 
-    watcher.watch(parent_path, RecursiveMode::NonRecursive)?;
+    watcher.watch(parent_path, RecursiveMode::Recursive)?;
     info!("Start watching the config");
 
     loop {


### PR DESCRIPTION
https://github.com/rapiz1/rathole/issues/359