### PR TITLE
Implement prefer IPv6 option for the client

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -110,7 +110,6 @@ impl<T: 'static + Transport> Client<T> {
             let handle = ControlChannelHandle::new(
                 (*config).clone(),
                 self.config.remote_addr.clone(),
-                self.config.prefer_ipv6,
                 self.transport.clone(),
                 self.config.heartbeat_timeout,
             );
@@ -153,7 +152,6 @@ impl<T: 'static + Transport> Client<T> {
                     let handle = ControlChannelHandle::new(
                         cfg,
                         self.config.remote_addr.clone(),
-                        self.config.prefer_ipv6,
                         self.transport.clone(),
                         self.config.heartbeat_timeout,
                     );
@@ -392,7 +390,6 @@ struct ControlChannel<T: Transport> {
     service: ClientServiceConfig,       // `[client.services.foo]` config block
     shutdown_rx: oneshot::Receiver<u8>, // Receives the shutdown signal
     remote_addr: String,                // `client.remote_addr`
-    prefer_ipv6: Option<bool>,
     transport: Arc<T>,                  // Wrapper around the transport layer
     heartbeat_timeout: u64,             // Application layer heartbeat timeout in secs
 }
@@ -502,7 +499,6 @@ impl ControlChannelHandle {
     fn new<T: 'static + Transport>(
         service: ClientServiceConfig,
         remote_addr: String,
-        prefer_ipv6: Option<bool>,
         transport: Arc<T>,
         heartbeat_timeout: u64,
     ) -> ControlChannelHandle {
@@ -518,7 +514,6 @@ impl ControlChannelHandle {
             service,
             shutdown_rx,
             remote_addr,
-            prefer_ipv6,
             transport,
             heartbeat_timeout,
         };

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,6 +110,7 @@ impl<T: 'static + Transport> Client<T> {
             let handle = ControlChannelHandle::new(
                 (*config).clone(),
                 self.config.remote_addr.clone(),
+                self.config.prefer_ipv6,
                 self.transport.clone(),
                 self.config.heartbeat_timeout,
             );
@@ -152,6 +153,7 @@ impl<T: 'static + Transport> Client<T> {
                     let handle = ControlChannelHandle::new(
                         cfg,
                         self.config.remote_addr.clone(),
+                        self.config.prefer_ipv6,
                         self.transport.clone(),
                         self.config.heartbeat_timeout,
                     );
@@ -227,7 +229,7 @@ async fn run_data_channel<T: Transport>(args: Arc<RunDataChannelArgs<T>>) -> Res
             if args.service.service_type != ServiceType::Udp {
                 bail!("Expect UDP traffic. Please check the configuration.")
             }
-            run_data_channel_for_udp::<T>(conn, &args.service.local_addr).await?;
+            run_data_channel_for_udp::<T>(conn, &args.service.local_addr, args.service.prefer_ipv6).await?;
         }
     }
     Ok(())
@@ -255,7 +257,7 @@ async fn run_data_channel_for_tcp<T: Transport>(
 type UdpPortMap = Arc<RwLock<HashMap<SocketAddr, mpsc::Sender<Bytes>>>>;
 
 #[instrument(skip(conn))]
-async fn run_data_channel_for_udp<T: Transport>(conn: T::Stream, local_addr: &str) -> Result<()> {
+async fn run_data_channel_for_udp<T: Transport>(conn: T::Stream, local_addr: &str, prefer_ipv6: bool) -> Result<()> {
     debug!("New data channel starts forwarding");
 
     let port_map: UdpPortMap = Arc::new(RwLock::new(HashMap::new()));
@@ -305,7 +307,7 @@ async fn run_data_channel_for_udp<T: Transport>(conn: T::Stream, local_addr: &st
             // grabbing the writer lock
             let mut m = port_map.write().await;
 
-            match udp_connect(local_addr).await {
+            match udp_connect(local_addr, prefer_ipv6).await {
                 Ok(s) => {
                     let (inbound_tx, inbound_rx) = mpsc::channel(UDP_SENDQ_SIZE);
                     m.insert(packet.from, inbound_tx);
@@ -390,6 +392,7 @@ struct ControlChannel<T: Transport> {
     service: ClientServiceConfig,       // `[client.services.foo]` config block
     shutdown_rx: oneshot::Receiver<u8>, // Receives the shutdown signal
     remote_addr: String,                // `client.remote_addr`
+    prefer_ipv6: Option<bool>,
     transport: Arc<T>,                  // Wrapper around the transport layer
     heartbeat_timeout: u64,             // Application layer heartbeat timeout in secs
 }
@@ -499,6 +502,7 @@ impl ControlChannelHandle {
     fn new<T: 'static + Transport>(
         service: ClientServiceConfig,
         remote_addr: String,
+        prefer_ipv6: Option<bool>,
         transport: Arc<T>,
         heartbeat_timeout: u64,
     ) -> ControlChannelHandle {
@@ -514,6 +518,7 @@ impl ControlChannelHandle {
             service,
             shutdown_rx,
             remote_addr,
+            prefer_ipv6,
             transport,
             heartbeat_timeout,
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ pub struct ClientServiceConfig {
     #[serde(skip)]
     pub name: String,
     pub local_addr: String,
+    #[serde(default)] // Default to false
     pub prefer_ipv6: bool,
     pub token: Option<MaskedString>,
     pub nodelay: Option<bool>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ pub struct ClientServiceConfig {
     #[serde(skip)]
     pub name: String,
     pub local_addr: String,
+    pub prefer_ipv6: bool,
     pub token: Option<MaskedString>,
     pub nodelay: Option<bool>,
     pub retry_interval: Option<u64>,
@@ -201,6 +202,7 @@ fn default_client_retry_interval() -> u64 {
 pub struct ClientConfig {
     pub remote_addr: String,
     pub default_token: Option<MaskedString>,
+    pub prefer_ipv6: Option<bool>,
     pub services: HashMap<String, ClientServiceConfig>,
     #[serde(default)]
     pub transport: TransportConfig,

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -71,13 +71,6 @@ pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result
     match prefer_ipv6 {
         false => {
             socket_addr = to_socket_addr(addr).await?;
-pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result<UdpSocket> {
-
-    let (socket_addr, bind_addr);
-
-    match prefer_ipv6 {
-        false => {
-            socket_addr = to_socket_addr(addr).await?;
 
             bind_addr = match socket_addr {
                 SocketAddr::V4(_) => "0.0.0.0:0",

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -90,6 +90,7 @@ pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result
                     let socket_addr_ipv4 = all_host_addresses.iter().find(|x| x.is_ipv4());
                     match socket_addr_ipv4 {
                         None => return Err(anyhow!("Failed to lookup the host")),
+                        // fallback to IPv4
                         Some(socket_addr_ipv4) => {
                             socket_addr = socket_addr_ipv4.clone();
                             bind_addr = "0.0.0.0:0";

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -83,7 +83,7 @@ pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result
             // Try to find an IPv6 address
             match all_host_addresses.clone().iter().find(|x| x.is_ipv6()) {
                 Some(socket_addr_ipv6) => {
-                    socket_addr = socket_addr_ipv6.clone();
+                    socket_addr = *socket_addr_ipv6;
                     bind_addr = ":::0";
                 },
                 None => {
@@ -92,7 +92,7 @@ pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result
                         None => return Err(anyhow!("Failed to lookup the host")),
                         // fallback to IPv4
                         Some(socket_addr_ipv4) => {
-                            socket_addr = socket_addr_ipv4.clone();
+                            socket_addr = *socket_addr_ipv4;
                             bind_addr = "0.0.0.0:0";
                         }
                     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -64,16 +64,43 @@ pub fn host_port_pair(s: &str) -> Result<(&str, u16)> {
 }
 
 /// Create a UDP socket and connect to `addr`
-pub async fn udp_connect<A: ToSocketAddrs>(addr: A) -> Result<UdpSocket> {
-    let addr = to_socket_addr(addr).await?;
+pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result<UdpSocket> {
 
-    let bind_addr = match addr {
-        SocketAddr::V4(_) => "0.0.0.0:0",
-        SocketAddr::V6(_) => ":::0",
+    let (socket_addr, bind_addr);
+
+    match prefer_ipv6 {
+        false => {
+            socket_addr = to_socket_addr(addr).await?;
+
+            bind_addr = match socket_addr {
+                SocketAddr::V4(_) => "0.0.0.0:0",
+                SocketAddr::V6(_) => ":::0",
+            };
+        },
+        true => {
+            let all_host_addresses: Vec<SocketAddr> = lookup_host(addr).await?.collect();
+
+            // Try to find an IPv6 address
+            match all_host_addresses.clone().iter().find(|x| x.is_ipv6()) {
+                Some(socket_addr_ipv6) => {
+                    socket_addr = socket_addr_ipv6.clone();
+                    bind_addr = ":::0";
+                },
+                None => {
+                    let socket_addr_ipv4 = all_host_addresses.iter().find(|x| x.is_ipv4());
+                    match socket_addr_ipv4 {
+                        None => return Err(anyhow!("Failed to lookup the host")),
+                        Some(socket_addr_ipv4) => {
+                            socket_addr = socket_addr_ipv4.clone();
+                            bind_addr = "0.0.0.0:0";
+                        }
+                    }
+                }
+            }
+        }
     };
-
     let s = UdpSocket::bind(bind_addr).await?;
-    s.connect(addr).await?;
+    s.connect(socket_addr).await?;
     Ok(s)
 }
 

--- a/tests/config_test/valid_config/full.toml
+++ b/tests/config_test/valid_config/full.toml
@@ -1,7 +1,6 @@
 [client]
 remote_addr = "example.com:2333" # Necessary. The address of the server
 default_token = "default_token_if_not_specify" # Optional. The default token of services, if they don't define their own ones
-prefer_ipv6 = false # Optional. If the client prefers to use IPv6 when connecting to the server (e.g.: When the client is behind an ISP's NAT). Default: false
 
 [client.transport]
 type = "tcp" # Optional. Possible values: ["tcp", "tls"]. Default: "tcp"
@@ -18,6 +17,7 @@ remote_public_key = "key_encoded_in_base64" # Optional
 [client.services.service1] # A service that needs forwarding. The name `service1` can change arbitrarily, as long as identical to the name in the server's configuration
 type = "tcp" # Optional. The protocol that needs forwarding. Possible values: ["tcp", "udp"]. Default: "tcp"
 token = "whatever" # Necessary if `client.default_token` not set
+prefer_ipv6 = false # Optional. If the client prefers to use IPv6 when connecting to the server (e.g.: When the client is behind an ISP's NAT). Default: false
 local_addr = "127.0.0.1:1081" # Necessary. The address of the service that needs to be forwarded
 
 [client.services.service2] # Multiple services can be defined

--- a/tests/config_test/valid_config/full.toml
+++ b/tests/config_test/valid_config/full.toml
@@ -1,6 +1,7 @@
 [client]
 remote_addr = "example.com:2333" # Necessary. The address of the server
 default_token = "default_token_if_not_specify" # Optional. The default token of services, if they don't define their own ones
+prefer_ipv6 = false # Optional. If the client prefers to use IPv6 when connecting to the server (e.g.: When the client is behind an ISP's NAT). Default: false
 
 [client.transport]
 type = "tcp" # Optional. Possible values: ["tcp", "tls"]. Default: "tcp"


### PR DESCRIPTION
This implements #184 
I tested it manually behind my ISP's Dual Stack lite with an external Server supporting both ipv4 and ipv6. Both A and AAAA registries were added for the tested domain.