### PR TITLE
Enhance systemd security

### DIFF
--- a/examples/systemd/rathole@.service
+++ b/examples/systemd/rathole@.service
@@ -13,5 +13,22 @@ ExecStart=/usr/bin/rathole /etc/rathole/%i.toml
 # without root
 # ExecStart=%h/.local/bin/rathole %h/.local/etc/rathole/%i.toml
 
+# Enhance Security
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/rathole@.service
+++ b/examples/systemd/rathole@.service
@@ -29,6 +29,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec.service
+++ b/examples/systemd/ratholec.service
@@ -29,6 +29,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec.service
+++ b/examples/systemd/ratholec.service
@@ -13,5 +13,22 @@ ExecStart=/usr/bin/rathole -c /etc/rathole/rathole.toml
 # without root
 # ExecStart=%h/.local/bin/rathole -c %h/.local/etc/rathole/rathole.toml
 
+# Enhance Security
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec@.service
+++ b/examples/systemd/ratholec@.service
@@ -13,5 +13,22 @@ ExecStart=/usr/bin/rathole -c /etc/rathole/%i.toml
 # without root
 # ExecStart=%h/.local/bin/rathole -c %h/.local/etc/rathole/%i.toml
 
+# Enhance Security
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholec@.service
+++ b/examples/systemd/ratholec@.service
@@ -29,6 +29,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholes.service
+++ b/examples/systemd/ratholes.service
@@ -13,5 +13,22 @@ ExecStart=/usr/bin/rathole -s /etc/rathole/rathole.toml
 # without root
 # ExecStart=%h/.local/bin/rathole -s %h/.local/etc/rathole/rathole.toml
 
+# Enhance Security
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholes.service
+++ b/examples/systemd/ratholes.service
@@ -29,6 +29,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholes@.service
+++ b/examples/systemd/ratholes@.service
@@ -29,6 +29,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 RestrictSUIDSGID=yes
 LockPersonality=yes
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd/ratholes@.service
+++ b/examples/systemd/ratholes@.service
@@ -13,5 +13,22 @@ ExecStart=/usr/bin/rathole -s /etc/rathole/%i.toml
 # without root
 # ExecStart=%h/.local/bin/rathole -s %h/.local/etc/rathole/%i.toml
 
+# Enhance Security
+DynamicUser=yes
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It's a very bad practice to run an exposed networking service as root, and rathole shouldn't recommend doing that. Here are some changes to enhance security:

- `DynamicUser=yes` – Run the binary in its own minimal-privilege user.
- `NoNewPrivileges=yes` – Prevents privilege escalation.
- `PrivateTmp=yes` – Isolates `/tmp` and `/var/tmp` to prevent interference.
- `PrivateDevices=yes` and `DevicePolicy=closed` – Restricts access to device files.
- `ProtectSystem=strict` – Makes the filesystem read-only except for essential directories.
- `ProtectHome=read-only` – Prevents modification of user home directories.
- `ProtectControlGroups=yes`, `ProtectKernelModules=yes`, `ProtectKernelTunables=yes` – Restricts access to kernel-related settings.
- `RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK` – Limits allowed network families.
- `RestrictNamespaces=yes` – Disables namespace usage to prevent container escape vulnerabilities.
- `RestrictRealtime=yes` and `RestrictSUIDSGID=yes` – Prevents real-time scheduling abuse and SUID/SGID privilege escalation.
- `LockPersonality=yes` – Prevents personality changes to avoid exploits.
- `AmbientCapabilities=CAP_NET_BIND_SERVICE` – Allow binding to lower port numbers (e.g. 80)