### PR TITLE
ci: Use tar.gz for linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,20 +130,31 @@ jobs:
         with:
           name: rathole-${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.exe }}
-      - name: Zip Release
+
+      - name: Compress Release for Windows and macOS
+        if: matrix.os == 'windows-latest' || matrix.os == 'macos-latest'
         uses: TheDoctor0/zip-release@0.6.1
         with:
           type: zip
           filename: rathole-${{ matrix.target }}.zip
           directory: target/${{ matrix.target }}/release/
           path: ${{ matrix.exe }}
+      - name: Compress Release for Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf rathole-${{ matrix.target }}.tar.gz ${{ matrix.exe }}
+
       - name: Publish
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: target/${{ matrix.target }}/release/rathole-${{ matrix.target }}.zip
+          files: >
+            ${{ matrix.os == 'ubuntu-latest' && format('target/{0}/release/rathole-{0}.tar.gz', matrix.target) || 
+                  format('target/{0}/release/rathole-{0}.zip', matrix.target) }}
           generate_release_notes: true
           draft: true
+
   docker:
     name: Publish to Docker Hub
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
I think using tar.gz than zip would be better for linux build. Some distros don't have zip/unzip by default but tar.