### PR TITLE
Add CAcreateserial option to self-signed cert script

### DIFF
--- a/examples/tls/create_self_signed_cert.sh
+++ b/examples/tls/create_self_signed_cert.sh
@@ -51,6 +51,7 @@ EOF
 openssl x509 -req \
     -in server.csr \
     -CA rootCA.crt -CAkey rootCA.key \
+    -CAcreateserial \
     -out server.crt \
     -days 365 \
     -sha256 -extfile cert.conf


### PR DESCRIPTION
New versions of openssl require this option for the script to work as standalone