### PR TITLE
ci: change registry to publish to ghcr.io instead of dockerhub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,25 +145,28 @@ jobs:
           generate_release_notes: true
           draft: true
   docker:
-    name: Publish to Docker Hub
+    name: Publish to GitHub Container Registry
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      packages: write
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
           platforms: linux/amd64, linux/arm64, linux/armhf, linux/armv7
-          tags: rapiz1/rathole:latest, rapiz1/rathole:${{ github.ref_name }}
+          tags: ghcr.io/${{ github.repository }}:latest, ghcr.io/${{ github.repository }}:${{ github.ref_name }}
   publish-crate:
     name: Publish to crates.io
     if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
closes #428 