### PR TITLE
fix: replace copy_bidirectional with select!+copy to prevent TCP conn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ remote_addr = "example.com:2333" # Necessary. The address of the server
 default_token = "default_token_if_not_specify" # Optional. The default token of services, if they don't define their own ones
 heartbeat_timeout = 40 # Optional. Set to 0 to disable the application-layer heartbeat test. The value must be greater than `server.heartbeat_interval`. Default: 40 seconds
 retry_interval = 1 # Optional. The interval between retry to connect to the server. Default: 1 second
+post_half_close_idle_timeout = 120 # Optional. Idle deadline applied to a forwarder once one peer has half-closed; see the dedicated section below. Use `"off"` to disable (legacy behavior). Default: 120
 
 [client.transport] # The whole block is optional. Specify which transport to use
 type = "tcp" # Optional. Possible values: ["tcp", "tls", "noise"]. Default: "tcp"
@@ -145,6 +146,7 @@ local_addr = "127.0.0.1:1082"
 bind_addr = "0.0.0.0:2333" # Necessary. The address that the server listens for clients. Generally only the port needs to be change.
 default_token = "default_token_if_not_specify" # Optional
 heartbeat_interval = 30 # Optional. The interval between two application-layer heartbeat. Set to 0 to disable sending heartbeat. Default: 30 seconds
+post_half_close_idle_timeout = 120 # Optional. Idle deadline applied to a forwarder once one peer has half-closed; see the dedicated section below. Use `"off"` to disable (legacy behavior). Default: 120
 
 [server.transport] # Same as `[client.transport]`
 type = "tcp"
@@ -197,6 +199,27 @@ If `RUST_LOG` is not present, the default logging level is `info`.
 From v0.4.7, rathole enables TCP_NODELAY by default, which should benefit the latency and interactive applications like rdp, Minecraft servers. However, it slightly decreases the bandwidth.
 
 If the bandwidth is more important, TCP_NODELAY can be opted out with `nodelay = false`.
+
+### `post_half_close_idle_timeout`
+
+When a forwarded peer sends `FIN` (half-closes its write side) but never closes its own read side, the underlying socket can sit indefinitely in `CLOSE-WAIT` / `FIN-WAIT-2`. Over time these orphaned sockets accumulate. The `post_half_close_idle_timeout` option is the leak guard for that pattern.
+
+**How it arms.** While both directions of a forwarder are still carrying bytes, no timeout applies — long-lived idle full-duplex connections (SSH, MQTT keepalive, long-poll) are unaffected. The deadline only arms once one direction has reached EOF and that EOF has been propagated as `shutdown(SHUT_WR)` to the peer's write side. From that point on, the surviving direction must read at least one byte (or hit EOF / error) within the configured window, otherwise the forwarder is reaped and both ends are torn down.
+
+**Per-step deadline.** The deadline is checked at every read, write and flush — not just reads — so a peer that half-closes and then stops draining its read side cannot wedge the forwarder inside `write_all` via TCP backpressure.
+
+**Configuration.**
+- Set on `[client]` and `[server]` blocks at top level. Hot-reload of these top-level fields restarts the running instance; service-level edits remain incremental.
+- Accepts a non-negative integer (seconds) or the string `"off"` (disables the timeout entirely; legacy `copy_bidirectional` behavior).
+- Default is `120` seconds.
+- `0` is allowed and means "tear down immediately on half-close" — useful for protocols that never half-close legitimately.
+
+**Per-transport behavior.**
+- `tcp`, `tls`, `noise`: full half-close-then-respond preserved. The leak guard only arms the timeout after the surviving direction enters its post-EOF idle phase.
+- `socket_stream` (Unix domain sockets): same as TCP.
+- `websocket`, `websocket` (TLS): WebSocket cannot carry a half-close-then-respond pattern — RFC 6455 requires the receiver of a Close frame to reply with its own Close, which closes its sending side too. The timeout still bounds cleanup but cannot change the protocol's full-close semantics.
+
+**Observability.** Every reap is logged at debug level with the message `Forwarder (...) reaped by post-half-close idle timeout`. To verify the leak guard is firing in production, run with `RUST_LOG=rathole=debug` and grep for that line.
 
 ## Benchmark
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use crate::protocol::{
     self, read_ack, read_control_cmd, read_data_cmd, read_hello, Ack, Auth, ControlChannelCmd,
     DataChannelCmd, UdpTraffic, CURRENT_PROTO_VERSION, HASH_WIDTH_IN_BYTES,
 };
+use crate::forward::forward_bidirectional_with_idle_timeout;
 use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport};
 use anyhow::{anyhow, bail, Context, Result};
 use backoff::backoff::Backoff;
@@ -15,7 +16,7 @@ use bytes::{Bytes, BytesMut};
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UdpSocket};
 use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
 use tokio::time::{self, Duration, Instant};
@@ -83,6 +84,18 @@ pub async fn run_client(
 type ServiceDigest = protocol::Digest;
 type Nonce = protocol::Digest;
 
+// Surface the outcome of a forwarder task. Only the leak-guard reaper
+// (the typed `PostHalfCloseIdleTimeout` sentinel) is debug-level; generic
+// `TimedOut` from a transport could indicate a real handshake / keepalive
+// problem and stays at warn.
+fn log_forwarder_outcome(kind: &'static str, e: &io::Error) {
+    if crate::forward::is_post_half_close_idle_timeout(e) {
+        debug!("Forwarder ({}) reaped by post-half-close idle timeout", kind);
+    } else {
+        warn!("Forwarder ({}) ended with error: {}", kind, e);
+    }
+}
+
 // Holds the state of a client
 struct Client<T: Transport> {
     config: ClientConfig,
@@ -115,6 +128,7 @@ impl<T: 'static + Transport> Client<T> {
                 self.config.remote_addr.clone(),
                 self.transport.clone(),
                 self.config.heartbeat_timeout,
+                self.config.post_half_close_idle_timeout.as_duration(),
             );
             self.service_handles.insert(name.clone(), handle);
         }
@@ -157,6 +171,7 @@ impl<T: 'static + Transport> Client<T> {
                         self.config.remote_addr.clone(),
                         self.transport.clone(),
                         self.config.heartbeat_timeout,
+                        self.config.post_half_close_idle_timeout.as_duration(),
                     );
                     let _ = self.service_handles.insert(name, handle);
                 }
@@ -175,6 +190,7 @@ struct RunDataChannelArgs<T: Transport> {
     connector: Arc<T>,
     socket_opts: SocketOpts,
     service: ClientServiceConfig,
+    post_half_close_idle_timeout: Option<Duration>,
 }
 
 async fn do_data_channel_handshake<T: Transport>(
@@ -224,7 +240,12 @@ async fn run_data_channel<T: Transport>(args: Arc<RunDataChannelArgs<T>>) -> Res
             if args.service.service_type != ServiceType::Tcp {
                 bail!("Expect TCP traffic. Please check the configuration.")
             }
-            run_data_channel_for_tcp::<T>(conn, &args.service.local_addr).await?;
+            run_data_channel_for_tcp::<T>(
+                conn,
+                &args.service.local_addr,
+                args.post_half_close_idle_timeout,
+            )
+            .await?;
         }
         DataChannelCmd::StartForwardUdp => {
             if args.service.service_type != ServiceType::Udp {
@@ -238,23 +259,33 @@ async fn run_data_channel<T: Transport>(args: Arc<RunDataChannelArgs<T>>) -> Res
             if args.service.service_type != ServiceType::SocketStream {
                 bail!("Expect SocketStream traffic. Please check the configuration.")
             }
-            run_data_channel_for_socket_stream::<T>(conn, &args.service.local_addr).await?;
+            run_data_channel_for_socket_stream::<T>(
+                conn,
+                &args.service.local_addr,
+                args.post_half_close_idle_timeout,
+            )
+            .await?;
         }
     }
     Ok(())
 }
 
-// Simply copying back and forth for TCP
+// Two-phase bidirectional forwarding for TCP. See `crate::forward`.
 #[instrument(skip(conn))]
 async fn run_data_channel_for_tcp<T: Transport>(
-    mut conn: T::Stream,
+    conn: T::Stream,
     local_addr: &str,
+    post_half_close_idle_timeout: Option<Duration>,
 ) -> Result<()> {
     debug!("New data channel starts forwarding");
-    let mut local = TcpStream::connect(local_addr)
+    let local = TcpStream::connect(local_addr)
         .await
         .with_context(|| format!("Failed to connect to {}", local_addr))?;
-    let _ = copy_bidirectional(&mut conn, &mut local).await;
+    if let Err(e) =
+        forward_bidirectional_with_idle_timeout(conn, local, post_half_close_idle_timeout).await
+    {
+        log_forwarder_outcome("tcp", &e);
+    }
     Ok(())
 }
 
@@ -347,15 +378,20 @@ async fn run_data_channel_for_udp<T: Transport>(
 
 #[cfg(unix)]
 async fn run_data_channel_for_socket_stream<T: Transport>(
-    mut conn: T::Stream,
+    conn: T::Stream,
     local_addr: &str,
+    post_half_close_idle_timeout: Option<Duration>,
 ) -> Result<()> {
     debug!("New data channel starts forwarding");
 
-    let mut local = UnixStream::connect(local_addr)
+    let local = UnixStream::connect(local_addr)
         .await
         .with_context(|| format!("Failed to connect to {}", local_addr))?;
-    let _ = copy_bidirectional(&mut conn, &mut local).await;
+    if let Err(e) =
+        forward_bidirectional_with_idle_timeout(conn, local, post_half_close_idle_timeout).await
+    {
+        log_forwarder_outcome("socket_stream", &e);
+    }
     Ok(())
 }
 
@@ -420,6 +456,7 @@ struct ControlChannel<T: Transport> {
     remote_addr: String,                // `client.remote_addr`
     transport: Arc<T>,                  // Wrapper around the transport layer
     heartbeat_timeout: u64,             // Application layer heartbeat timeout in secs
+    post_half_close_idle_timeout: Option<Duration>,
 }
 
 // Handle of a control channel
@@ -489,6 +526,7 @@ impl<T: 'static + Transport> ControlChannel<T> {
             connector: self.transport.clone(),
             socket_opts,
             service: self.service.clone(),
+            post_half_close_idle_timeout: self.post_half_close_idle_timeout,
         });
 
         loop {
@@ -529,6 +567,7 @@ impl ControlChannelHandle {
         remote_addr: String,
         transport: Arc<T>,
         heartbeat_timeout: u64,
+        post_half_close_idle_timeout: Option<Duration>,
     ) -> ControlChannelHandle {
         let digest = protocol::digest(service.name.as_bytes());
 
@@ -544,6 +583,7 @@ impl ControlChannelHandle {
             remote_addr,
             transport,
             heartbeat_timeout,
+            post_half_close_idle_timeout,
         };
 
         tokio::spawn(

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,11 @@ const DEFAULT_HEARTBEAT_TIMEOUT_SECS: u64 = 40;
 /// Client
 const DEFAULT_CLIENT_RETRY_INTERVAL_SECS: u64 = 1;
 
+/// How long the surviving direction may stay idle after the peer has
+/// half-closed before the forwarder tears the connection down. Only the
+/// surviving direction is bounded — full-duplex idle traffic is unaffected.
+const DEFAULT_POST_HALF_CLOSE_IDLE_TIMEOUT_SECS: u64 = 120;
+
 /// String with Debug implementation that emits "MASKED"
 /// Used to mask sensitive strings when logging
 #[derive(Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
@@ -238,6 +243,77 @@ fn default_client_retry_interval() -> u64 {
     DEFAULT_CLIENT_RETRY_INTERVAL_SECS
 }
 
+fn default_post_half_close_idle_timeout() -> PostHalfCloseIdleTimeout {
+    PostHalfCloseIdleTimeout(Some(DEFAULT_POST_HALF_CLOSE_IDLE_TIMEOUT_SECS))
+}
+
+/// Configurable post-half-close idle timeout. Accepts either a non-negative
+/// integer (seconds) or the string `"off"` (disables the timeout entirely,
+/// restoring legacy `copy_bidirectional` behavior).
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct PostHalfCloseIdleTimeout(pub Option<u64>);
+
+impl Default for PostHalfCloseIdleTimeout {
+    /// Match the serde missing-field default so a programmatic
+    /// `ClientConfig::default()` / `ServerConfig::default()` doesn't silently
+    /// disable the leak guard.
+    fn default() -> Self {
+        PostHalfCloseIdleTimeout(Some(DEFAULT_POST_HALF_CLOSE_IDLE_TIMEOUT_SECS))
+    }
+}
+
+impl PostHalfCloseIdleTimeout {
+    pub fn as_duration(&self) -> Option<std::time::Duration> {
+        self.0.map(std::time::Duration::from_secs)
+    }
+}
+
+impl Serialize for PostHalfCloseIdleTimeout {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self.0 {
+            Some(v) => s.serialize_u64(v),
+            None => s.serialize_str("off"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PostHalfCloseIdleTimeout {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct V;
+        impl<'de> serde::de::Visitor<'de> for V {
+            type Value = PostHalfCloseIdleTimeout;
+
+            fn expecting(&self, f: &mut Formatter) -> std::fmt::Result {
+                f.write_str(r#"a non-negative integer (seconds) or the string "off""#)
+            }
+
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                Ok(PostHalfCloseIdleTimeout(Some(v)))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                if v < 0 {
+                    Err(E::custom("post_half_close_idle_timeout must be >= 0"))
+                } else {
+                    Ok(PostHalfCloseIdleTimeout(Some(v as u64)))
+                }
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                if v.eq_ignore_ascii_case("off") {
+                    Ok(PostHalfCloseIdleTimeout(None))
+                } else {
+                    Err(E::custom(format!(
+                        r#"expected non-negative integer or "off", got {:?}"#,
+                        v
+                    )))
+                }
+            }
+        }
+        d.deserialize_any(V)
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ClientConfig {
@@ -251,6 +327,8 @@ pub struct ClientConfig {
     pub heartbeat_timeout: u64,
     #[serde(default = "default_client_retry_interval")]
     pub retry_interval: u64,
+    #[serde(default = "default_post_half_close_idle_timeout")]
+    pub post_half_close_idle_timeout: PostHalfCloseIdleTimeout,
 }
 
 fn default_heartbeat_interval() -> u64 {
@@ -267,6 +345,8 @@ pub struct ServerConfig {
     pub transport: TransportConfig,
     #[serde(default = "default_heartbeat_interval")]
     pub heartbeat_interval: u64,
+    #[serde(default = "default_post_half_close_idle_timeout")]
+    pub post_half_close_idle_timeout: PostHalfCloseIdleTimeout,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
@@ -532,5 +612,86 @@ mod tests {
             "4"
         );
         Ok(())
+    }
+
+    #[test]
+    fn post_half_close_idle_timeout_roundtrip() {
+        // Default: programmatic Default and serde missing-field must agree.
+        assert_eq!(
+            PostHalfCloseIdleTimeout::default().0,
+            Some(DEFAULT_POST_HALF_CLOSE_IDLE_TIMEOUT_SECS),
+        );
+
+        let parsed: ClientConfig = toml::from_str(
+            r#"
+remote_addr = "x:1"
+default_token = "t"
+[services]
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            parsed.post_half_close_idle_timeout.0,
+            Some(DEFAULT_POST_HALF_CLOSE_IDLE_TIMEOUT_SECS),
+            "missing field must default to {DEFAULT_POST_HALF_CLOSE_IDLE_TIMEOUT_SECS}s"
+        );
+
+        // Numeric value.
+        let parsed: ClientConfig = toml::from_str(
+            r#"
+remote_addr = "x:1"
+default_token = "t"
+post_half_close_idle_timeout = 30
+[services]
+"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.post_half_close_idle_timeout.0, Some(30));
+
+        // Zero is valid (immediate teardown after half-close).
+        let parsed: ClientConfig = toml::from_str(
+            r#"
+remote_addr = "x:1"
+default_token = "t"
+post_half_close_idle_timeout = 0
+[services]
+"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.post_half_close_idle_timeout.0, Some(0));
+
+        // "off" disables the timeout entirely.
+        let parsed: ClientConfig = toml::from_str(
+            r#"
+remote_addr = "x:1"
+default_token = "t"
+post_half_close_idle_timeout = "off"
+[services]
+"#,
+        )
+        .unwrap();
+        assert_eq!(parsed.post_half_close_idle_timeout.0, None);
+
+        // Negative is rejected.
+        let err: Result<ClientConfig, _> = toml::from_str(
+            r#"
+remote_addr = "x:1"
+default_token = "t"
+post_half_close_idle_timeout = -1
+[services]
+"#,
+        );
+        assert!(err.is_err(), "negative must be rejected");
+
+        // Arbitrary string is rejected.
+        let err: Result<ClientConfig, _> = toml::from_str(
+            r#"
+remote_addr = "x:1"
+default_token = "t"
+post_half_close_idle_timeout = "later"
+[services]
+"#,
+        );
+        assert!(err.is_err(), "unknown string must be rejected");
     }
 }

--- a/src/forward.rs
+++ b/src/forward.rs
@@ -1,0 +1,563 @@
+//! Two-phase bidirectional stream forwarding with bounded post-half-close idle.
+//!
+//! Phase 1: both directions copy concurrently with no timeout.
+//! Phase 2: once one direction has reached EOF, its FIN is forwarded to the
+//! peer's write side via `shutdown()`; the surviving direction continues but
+//! must observe at least one byte of progress per `idle` interval, otherwise
+//! it is torn down. This bounds CLOSE-WAIT/FIN-WAIT-2 stalls when a peer
+//! never closes its own write side, while preserving the half-close-then-
+//! respond protocol semantics that `tokio::io::copy_bidirectional` provides.
+
+use std::time::Duration;
+use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::oneshot;
+
+/// Buffer size per direction. Matches Tokio's internal `io::copy` chunk size.
+const FORWARD_BUF_SIZE: usize = 8 * 1024;
+
+/// Forward bytes in both directions between `a` and `b` until either side
+/// closes (or errors). After the first side closes, the surviving direction
+/// is bounded by `idle`: every successful read resets the deadline; if the
+/// deadline fires the forwarder returns `Err(TimedOut)`. `None` disables the
+/// post-half-close timeout entirely (matching legacy `copy_bidirectional`
+/// behavior).
+pub(crate) async fn forward_bidirectional_with_idle_timeout<A, B>(
+    a: A,
+    b: B,
+    idle: Option<Duration>,
+) -> io::Result<()>
+where
+    A: AsyncRead + AsyncWrite + Unpin,
+    B: AsyncRead + AsyncWrite + Unpin,
+{
+    let (ar, aw) = io::split(a);
+    let (br, bw) = io::split(b);
+
+    // Each direction owns a oneshot it watches. When the other direction
+    // finishes Ok(()), the parent sends an idle Duration through the channel
+    // and the surviving pump arms its own per-read timeout.
+    let (atob_arm_tx, atob_arm_rx) = oneshot::channel::<Duration>();
+    let (btoa_arm_tx, btoa_arm_rx) = oneshot::channel::<Duration>();
+
+    let atob = pump(ar, bw, atob_arm_rx, idle);
+    let btoa = pump(br, aw, btoa_arm_rx, idle);
+    tokio::pin!(atob);
+    tokio::pin!(btoa);
+
+    tokio::select! {
+        r = &mut atob => match r {
+            Ok(()) => {
+                if let Some(t) = idle {
+                    let _ = btoa_arm_tx.send(t);
+                }
+                btoa.await
+            }
+            // Error in one direction tears down the other immediately, the
+            // same way `copy_bidirectional` returns on first error.
+            Err(e) => Err(e),
+        },
+        r = &mut btoa => match r {
+            Ok(()) => {
+                if let Some(t) = idle {
+                    let _ = atob_arm_tx.send(t);
+                }
+                atob.await
+            }
+            Err(e) => Err(e),
+        },
+    }
+}
+
+/// Marker error used as the inner error of the `io::Error` we raise on a
+/// post-half-close idle timeout. Kept module-private; downstream code that
+/// needs to recognize the leak-guard reaper goes through
+/// `is_post_half_close_idle_timeout`, not the type itself.
+#[derive(Debug)]
+struct PostHalfCloseIdleTimeout;
+
+impl std::fmt::Display for PostHalfCloseIdleTimeout {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("post half-close idle timeout")
+    }
+}
+
+impl std::error::Error for PostHalfCloseIdleTimeout {}
+
+fn post_half_close_idle_timeout_error() -> io::Error {
+    io::Error::new(io::ErrorKind::TimedOut, PostHalfCloseIdleTimeout)
+}
+
+/// True iff `e` is the leak-guard reaper we raised, not a generic
+/// transport-level `TimedOut` (TLS handshake, keepalive, etc.).
+pub(crate) fn is_post_half_close_idle_timeout(e: &io::Error) -> bool {
+    e.get_ref()
+        .and_then(|inner| inner.downcast_ref::<PostHalfCloseIdleTimeout>())
+        .is_some()
+}
+
+/// Read from `reader` and write to `writer` until reader EOFs or errors.
+/// `arm_idle` is the phase-1 → phase-2 trigger sent by the parent when the
+/// sibling pump finishes; `configured_idle` is the immutable upper bound the
+/// EOF `shutdown()` is allowed to take (so a transport whose `poll_shutdown`
+/// flushes protocol bytes — e.g. WebSocket's Close frame — cannot stall the
+/// pump indefinitely on an unresponsive peer).
+async fn pump<R, W>(
+    mut reader: R,
+    mut writer: W,
+    mut arm_idle: oneshot::Receiver<Duration>,
+    configured_idle: Option<Duration>,
+) -> io::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = [0u8; FORWARD_BUF_SIZE];
+    let mut idle: Option<Duration> = None;
+
+    loop {
+        let n = await_with_arm_or_timeout(reader.read(&mut buf), &mut arm_idle, &mut idle).await?;
+        if n == 0 {
+            return shutdown_with_optional_timeout(writer, configured_idle).await;
+        }
+        // Both `write_all` and `flush` must also race the arm/idle deadline:
+        // a peer that half-closes and then stops draining its read side
+        // would otherwise stall the surviving direction inside `write_all`
+        // (TCP backpressure) before the deadline can be applied.
+        //
+        // WebSocket writers buffer frames in `Sink::start_send` and only
+        // push them on `poll_flush`, so the explicit flush is also needed
+        // for transport correctness on `websocket{,_tls}` (see #460).
+        await_with_arm_or_timeout(writer.write_all(&buf[..n]), &mut arm_idle, &mut idle).await?;
+        await_with_arm_or_timeout(writer.flush(), &mut arm_idle, &mut idle).await?;
+    }
+}
+
+/// Bound the EOF-side `shutdown` by `idle`. When `idle` is `None` the
+/// behavior matches legacy `copy_bidirectional` (unbounded). On expiry the
+/// caller sees the same `PostHalfCloseIdleTimeout` sentinel as a phase-2
+/// stall, so log filtering treats it identically.
+async fn shutdown_with_optional_timeout<W>(mut writer: W, idle: Option<Duration>) -> io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    match idle {
+        None => writer.shutdown().await,
+        Some(t) => match tokio::time::timeout(t, writer.shutdown()).await {
+            Ok(r) => r,
+            Err(_) => Err(post_half_close_idle_timeout_error()),
+        },
+    }
+}
+
+/// Drive `fut` while remaining responsive to the phase-1 → phase-2 arm
+/// signal and, once armed, enforcing the per-step idle deadline. This means
+/// the deadline starts to apply at the granularity of every I/O step (read,
+/// write, flush) — not just reads — so a malicious peer cannot hide a stall
+/// inside a long `write_all`.
+async fn await_with_arm_or_timeout<F, T>(
+    fut: F,
+    arm: &mut oneshot::Receiver<Duration>,
+    idle: &mut Option<Duration>,
+) -> io::Result<T>
+where
+    F: std::future::Future<Output = io::Result<T>>,
+{
+    tokio::pin!(fut);
+    loop {
+        match *idle {
+            None => {
+                tokio::select! {
+                    biased; // prefer making progress on `fut` over arming idle
+                    r = &mut fut => return r,
+                    armed = &mut *arm => {
+                        if let Ok(t) = armed {
+                            *idle = Some(t);
+                        }
+                        // Loop again: now in `Some` branch.
+                    }
+                }
+            }
+            Some(t) => {
+                tokio::select! {
+                    biased;
+                    r = &mut fut => return r,
+                    _ = tokio::time::sleep(t) => {
+                        return Err(post_half_close_idle_timeout_error());
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::pin::Pin;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+    use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, ReadBuf};
+    use tokio::sync::Notify;
+    use tokio::time::timeout;
+
+    /// An `AsyncRead + AsyncWrite` wrapper that surfaces a `Notify` the moment
+    /// `poll_write` returns `Pending` for the first time. Tests use it to
+    /// deterministically know when the forwarder's pump is parked inside
+    /// `write_all` waiting on backpressure, without relying on a sleep race.
+    struct WriteStallProbe<S> {
+        inner: S,
+        first_pending: Arc<AtomicBool>,
+        notify: Arc<Notify>,
+    }
+
+    impl<S> WriteStallProbe<S> {
+        fn new(inner: S) -> (Self, Arc<Notify>) {
+            let notify = Arc::new(Notify::new());
+            let probe = WriteStallProbe {
+                inner,
+                first_pending: Arc::new(AtomicBool::new(false)),
+                notify: notify.clone(),
+            };
+            (probe, notify)
+        }
+    }
+
+    impl<S: AsyncWrite + Unpin> AsyncWrite for WriteStallProbe<S> {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let me = self.get_mut();
+            let r = Pin::new(&mut me.inner).poll_write(cx, buf);
+            if matches!(r, Poll::Pending)
+                && !me.first_pending.swap(true, Ordering::SeqCst)
+            {
+                me.notify.notify_waiters();
+            }
+            r
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_shutdown(cx)
+        }
+    }
+
+    impl<S: AsyncRead + Unpin> AsyncRead for WriteStallProbe<S> {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    /// An `AsyncRead + AsyncWrite` wrapper whose `poll_shutdown` never
+    /// completes. Models a transport whose shutdown handshake (e.g. WebSocket
+    /// `poll_close` flushing a Close frame on a non-draining peer) cannot
+    /// finish, so the `shutdown_with_optional_timeout` bound must reap it.
+    struct PendingShutdown<S> {
+        inner: S,
+    }
+
+    impl<S> PendingShutdown<S> {
+        fn new(inner: S) -> Self {
+            PendingShutdown { inner }
+        }
+    }
+
+    impl<S: AsyncWrite + Unpin> AsyncWrite for PendingShutdown<S> {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.get_mut().inner).poll_write(cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+    }
+
+    impl<S: AsyncRead + Unpin> AsyncRead for PendingShutdown<S> {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().inner).poll_read(cx, buf)
+        }
+    }
+
+    /// Phase-1 + clean phase-2: side A writes, half-closes, side B writes a
+    /// response after EOF, side A reads the response. Must succeed.
+    #[tokio::test]
+    async fn half_close_then_response_is_forwarded() {
+        let (a_outer, a_inner) = duplex(64);
+        let (b_outer, b_inner) = duplex(64);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_inner,
+            b_inner,
+            Some(Duration::from_secs(5)),
+        ));
+
+        let (mut a_r, mut a_w) = tokio::io::split(a_outer);
+        let (mut b_r, mut b_w) = tokio::io::split(b_outer);
+
+        // Visitor (a) sends request and half-closes.
+        a_w.write_all(b"req").await.unwrap();
+        a_w.shutdown().await.unwrap();
+
+        // Upstream (b) reads request + EOF, then writes response.
+        let mut got = [0u8; 3];
+        b_r.read_exact(&mut got).await.unwrap();
+        assert_eq!(&got, b"req");
+        let mut tail = [0u8; 1];
+        let n = b_r.read(&mut tail).await.unwrap();
+        assert_eq!(n, 0, "upstream must see FIN");
+        b_w.write_all(b"resp").await.unwrap();
+        b_w.shutdown().await.unwrap();
+
+        // Visitor reads response.
+        let mut resp = [0u8; 4];
+        a_r.read_exact(&mut resp).await.unwrap();
+        assert_eq!(&resp, b"resp");
+        let n = a_r.read(&mut [0u8; 1]).await.unwrap();
+        assert_eq!(n, 0);
+
+        timeout(Duration::from_secs(2), fwd)
+            .await
+            .expect("forwarder hung")
+            .unwrap()
+            .unwrap();
+    }
+
+    /// Phase-2 must bound write-side stalls too: A half-closes, B writes
+    /// faster than A reads (small duplex buffer). Once A stops draining,
+    /// the forwarder's `write_all` on A would block forever if the deadline
+    /// only covered reads. The per-step timeout must catch this.
+    #[tokio::test]
+    async fn stuck_writer_after_half_close_times_out() {
+        let (a_outer, a_inner) = duplex(8);
+        let (b_outer, b_inner) = duplex(8);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_inner,
+            b_inner,
+            Some(Duration::from_millis(200)),
+        ));
+
+        let (_a_r, mut a_w) = tokio::io::split(a_outer);
+        let (_b_r, mut b_w) = tokio::io::split(b_outer);
+
+        a_w.shutdown().await.unwrap();
+
+        // The producer write itself can backpressure; spawn it so the test
+        // doesn't deadlock if the forwarder regression makes it hang.
+        let producer = tokio::spawn(async move {
+            let _ = b_w.write_all(&[0u8; 4096]).await;
+        });
+
+        let res = timeout(Duration::from_secs(2), fwd)
+            .await
+            .expect("forwarder did not return — write-stall not bounded")
+            .unwrap();
+        let err = res.expect_err("expected TimedOut on stuck writer");
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+        producer.abort();
+    }
+
+    /// Round-2 regression, deterministic: when the phase-1 pump is already
+    /// parked inside `write_all` (because B has been streaming bytes), the
+    /// arm signal must still be processed even though the pump isn't
+    /// currently at the read select. Without `await_with_arm_or_timeout` the
+    /// pump would stay in phase 1 forever and the deadline would never apply.
+    ///
+    /// The `WriteStallProbe` wrapper notifies the test the *moment* pump's
+    /// `poll_write` returns Pending for the first time, replacing the prior
+    /// `sleep(50ms)` sync that could miss the in-progress write on slow CI.
+    #[tokio::test]
+    async fn arm_signal_during_phase1_write_still_bounds_stall() {
+        let (a_outer, a_inner) = duplex(8);
+        let (b_outer, b_inner) = duplex(8);
+
+        // Wrap A's inner end so we can observe when the forwarder's pump
+        // hits backpressure on the A-write side.
+        let (a_probe, write_pending) = WriteStallProbe::new(a_inner);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_probe,
+            b_inner,
+            Some(Duration::from_millis(200)),
+        ));
+
+        let (_a_r, mut a_w) = tokio::io::split(a_outer);
+        let (_b_r, mut b_w) = tokio::io::split(b_outer);
+
+        // B starts streaming first. Forwarder's pump_b_to_a reads + writes
+        // to A. A's _a_r doesn't drain, so write_all stalls in phase 1.
+        let producer = tokio::spawn(async move {
+            let _ = b_w.write_all(&[0u8; 4096]).await;
+        });
+
+        // Wait *deterministically* until the forwarder is wedged inside
+        // `write_all` on A. Cap the wait so a regression that prevents the
+        // pump from ever reaching write_all fails the test cleanly.
+        timeout(Duration::from_secs(2), write_pending.notified())
+            .await
+            .expect("forwarder never entered write_all on A");
+
+        // Now A half-closes — pump_a_to_b returns Ok, parent arms idle on
+        // pump_b_to_a. pump_b_to_a is currently inside write_all; the new
+        // helper must propagate the arm signal mid-write.
+        a_w.shutdown().await.unwrap();
+
+        let res = timeout(Duration::from_secs(2), fwd)
+            .await
+            .expect("forwarder did not return — arm signal lost during write_all")
+            .unwrap();
+        let err = res.expect_err("expected TimedOut after mid-write arm");
+        assert!(
+            is_post_half_close_idle_timeout(&err),
+            "expected the leak-guard sentinel, got {err}"
+        );
+        producer.abort();
+    }
+
+    /// Round-3 regression: a transport whose `poll_shutdown` flushes protocol
+    /// bytes (TLS close_notify, WebSocket Close frame, …) can stall on an
+    /// unresponsive peer. Phase-1 EOF used to call `writer.shutdown()`
+    /// without any deadline, so the pump would hang in there before the
+    /// sibling could be armed. `shutdown_with_optional_timeout` must bound it
+    /// by `configured_idle`.
+    #[tokio::test]
+    async fn eof_shutdown_is_bounded_by_configured_idle() {
+        let (a_outer, a_inner) = duplex(64);
+        let (_b_outer, b_inner) = duplex(64);
+
+        // B's inner side has a `poll_shutdown` that never completes. Pump
+        // a_to_b reads from a_inner, and on EOF calls `b_inner.shutdown()`
+        // — that's the call that must time out.
+        let b_inner = PendingShutdown::new(b_inner);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_inner,
+            b_inner,
+            Some(Duration::from_millis(150)),
+        ));
+
+        let (_a_r, mut a_w) = tokio::io::split(a_outer);
+        // Trigger EOF on A → pump_a_to_b reads 0 → calls b_inner.shutdown()
+        // which is the stuck path.
+        a_w.shutdown().await.unwrap();
+
+        let res = timeout(Duration::from_secs(2), fwd)
+            .await
+            .expect("forwarder did not return — EOF shutdown was unbounded")
+            .unwrap();
+        let err = res.expect_err("expected TimedOut on stuck shutdown");
+        assert!(
+            is_post_half_close_idle_timeout(&err),
+            "expected the leak-guard sentinel, got {err}"
+        );
+    }
+
+    /// Phase-2 idle: side A half-closes, side B never writes, never closes.
+    /// The forwarder must return TimedOut once `idle` elapses.
+    #[tokio::test]
+    async fn stuck_peer_after_half_close_times_out() {
+        let (a_outer, a_inner) = duplex(64);
+        let (_b_outer, b_inner) = duplex(64);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_inner,
+            b_inner,
+            Some(Duration::from_millis(150)),
+        ));
+
+        let (_a_r, mut a_w) = tokio::io::split(a_outer);
+        a_w.write_all(b"hi").await.unwrap();
+        a_w.shutdown().await.unwrap();
+
+        let res = timeout(Duration::from_secs(2), fwd)
+            .await
+            .expect("forwarder did not return")
+            .unwrap();
+        let err = res.expect_err("expected TimedOut");
+        assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+    }
+
+    /// `idle = None` must restore the legacy `copy_bidirectional` behavior:
+    /// after one side half-closes the surviving direction may sleep
+    /// indefinitely, so the forwarder does NOT terminate on its own.
+    #[tokio::test]
+    async fn idle_none_disables_phase2_timeout() {
+        let (a_outer, a_inner) = duplex(64);
+        let (_b_outer, b_inner) = duplex(64);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_inner, b_inner, None,
+        ));
+
+        let (_a_r, mut a_w) = tokio::io::split(a_outer);
+        a_w.shutdown().await.unwrap();
+
+        // Without an idle timeout, the forwarder should still be running.
+        let still_running = timeout(Duration::from_millis(300), fwd).await;
+        assert!(
+            still_running.is_err(),
+            "forwarder must not return when idle=None and the peer is silent"
+        );
+    }
+
+    /// Bidirectional steady traffic must keep flowing as long as both sides
+    /// make progress within `idle`, even if the interval is short.
+    #[tokio::test]
+    async fn steady_traffic_survives_short_idle() {
+        let (a_outer, a_inner) = duplex(64);
+        let (b_outer, b_inner) = duplex(64);
+
+        let fwd = tokio::spawn(forward_bidirectional_with_idle_timeout(
+            a_inner,
+            b_inner,
+            Some(Duration::from_millis(200)),
+        ));
+
+        let (mut a_r, mut a_w) = tokio::io::split(a_outer);
+        let (mut b_r, mut b_w) = tokio::io::split(b_outer);
+
+        // 5 round-trips spaced under the 200ms deadline.
+        for i in 0..5u8 {
+            a_w.write_all(&[i]).await.unwrap();
+            let mut got = [0u8; 1];
+            b_r.read_exact(&mut got).await.unwrap();
+            assert_eq!(got[0], i);
+            b_w.write_all(&[i ^ 0xff]).await.unwrap();
+            a_r.read_exact(&mut got).await.unwrap();
+            assert_eq!(got[0], i ^ 0xff);
+            tokio::time::sleep(Duration::from_millis(80)).await;
+        }
+
+        // Close both sides cleanly.
+        a_w.shutdown().await.unwrap();
+        b_w.shutdown().await.unwrap();
+
+        timeout(Duration::from_secs(2), fwd)
+            .await
+            .expect("forwarder hung")
+            .unwrap()
+            .unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod cli;
 mod config;
 mod config_watcher;
 mod constants;
+mod forward;
 mod helper;
 mod multi_map;
 mod protocol;

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,6 +8,7 @@ use crate::protocol::{
     self, read_auth, read_hello, Ack, ControlChannelCmd, DataChannelCmd, Hello, UdpTraffic,
     HASH_WIDTH_IN_BYTES,
 };
+use crate::forward::forward_bidirectional_with_idle_timeout;
 use crate::transport::{SocketOpts, TcpTransport, Transport};
 use anyhow::{anyhow, bail, Context, Result};
 use backoff::backoff::Backoff;
@@ -18,7 +19,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream, UdpSocket};
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio::time;
@@ -44,6 +45,18 @@ const SOCKET_STREAM_POOL_SIZE: usize = 8; // The number of cached connections fo
 
 const CHAN_SIZE: usize = 2048; // The capacity of various chans
 const HANDSHAKE_TIMEOUT: u64 = 5; // Timeout for transport handshake
+
+// Surface the outcome of a forwarder task. Only the leak-guard reaper
+// (the typed `PostHalfCloseIdleTimeout` sentinel) is debug-level; generic
+// `TimedOut` from a transport could indicate a real handshake / keepalive
+// problem and stays at warn.
+fn log_forwarder_outcome(kind: &'static str, e: &io::Error) {
+    if crate::forward::is_post_half_close_idle_timeout(e) {
+        debug!("Forwarder ({}) reaped by post-half-close idle timeout", kind);
+    } else {
+        warn!("Forwarder ({}) ended with error: {}", kind, e);
+    }
+}
 
 // The entrypoint of running a server
 pub async fn run_server(
@@ -355,8 +368,12 @@ async fn do_control_channel_handshake<T: 'static + Transport>(
         conn.flush().await?;
 
         info!(service = %service_config.name, "Control channel established");
-        let handle =
-            ControlChannelHandle::new(conn, service_config, server_config.heartbeat_interval);
+        let handle = ControlChannelHandle::new(
+            conn,
+            service_config,
+            server_config.heartbeat_interval,
+            server_config.post_half_close_idle_timeout.as_duration(),
+        );
 
         // Insert the new handle
         let _ = h.insert(service_digest, session_key, handle);
@@ -410,6 +427,7 @@ where
         conn: T::Stream,
         service: ServerServiceConfig,
         heartbeat_interval: u64,
+        post_half_close_idle_timeout: Option<Duration>,
     ) -> ControlChannelHandle<T> {
         // Create a shutdown channel
         let (shutdown_tx, shutdown_rx) = broadcast::channel::<bool>(1);
@@ -450,6 +468,7 @@ where
                     if let Err(e) = run_tcp_connection_pool::<T>(
                         bind_addr,
                         proxy_protocol.clone(),
+                        post_half_close_idle_timeout,
                         data_ch_rx,
                         data_ch_req_tx,
                         shutdown_rx_clone,
@@ -483,6 +502,7 @@ where
                 async move {
                     if let Err(e) = run_socket_stream_connection_pool::<T>(
                         bind_addr,
+                        post_half_close_idle_timeout,
                         data_ch_rx,
                         data_ch_req_tx,
                         shutdown_rx_clone,
@@ -751,6 +771,7 @@ fn socket_stream_listen_and_send(
 async fn run_tcp_connection_pool<T: Transport>(
     bind_addr: String,
     proxy_protocol: String,
+    post_half_close_idle_timeout: Option<Duration>,
     mut data_ch_rx: mpsc::Receiver<T::Stream>,
     data_ch_req_tx: mpsc::UnboundedSender<bool>,
     shutdown_rx: broadcast::Receiver<bool>,
@@ -758,16 +779,16 @@ async fn run_tcp_connection_pool<T: Transport>(
     let mut visitor_rx = tcp_listen_and_send(bind_addr, data_ch_req_tx.clone(), shutdown_rx);
     let cmd = bincode::serialize(&DataChannelCmd::StartForwardTcp).unwrap();
 
-    'pool: while let Some(mut visitor) = visitor_rx.recv().await {
+    'pool: while let Some(visitor) = visitor_rx.recv().await {
+        let mut visitor = Some(visitor);
         loop {
             if let Some(mut ch) = data_ch_rx.recv().await {
                 if write_and_flush(&mut ch, &cmd).await.is_ok() {
+                    let v = visitor.take().unwrap();
                     let proxy_proto = proxy_protocol.clone();
                     tokio::spawn(async move {
                         if !proxy_proto.is_empty() {
-                            let proxy_proto_header =
-                                generate_proxy_protocol_header(&visitor, &proxy_proto);
-                            match proxy_proto_header {
+                            match generate_proxy_protocol_header(&v, &proxy_proto) {
                                 Ok(header) => {
                                     let _ = ch.write_all(&header).await;
                                     let _ = ch.flush().await;
@@ -777,16 +798,30 @@ async fn run_tcp_connection_pool<T: Transport>(
                                 }
                             }
                         }
-                        let _ = copy_bidirectional(&mut ch, &mut visitor).await;
+                        if let Err(e) = forward_bidirectional_with_idle_timeout(
+                            ch,
+                            v,
+                            post_half_close_idle_timeout,
+                        )
+                        .await
+                        {
+                            log_forwarder_outcome("tcp", &e);
+                        }
                     });
                     break;
                 } else {
-                    // Current data channel is broken. Request for a new one
+                    // Current data channel is broken. Request for a new one.
                     if data_ch_req_tx.send(true).is_err() {
+                        if let Some(mut v) = visitor.take() {
+                            let _ = AsyncWriteExt::shutdown(&mut v).await;
+                        }
                         break 'pool;
                     }
                 }
             } else {
+                if let Some(mut v) = visitor.take() {
+                    let _ = AsyncWriteExt::shutdown(&mut v).await;
+                }
                 break 'pool;
             }
         }
@@ -800,6 +835,7 @@ async fn run_tcp_connection_pool<T: Transport>(
 #[instrument(skip_all)]
 async fn run_socket_stream_connection_pool<T: Transport>(
     bind_addr: String,
+    post_half_close_idle_timeout: Option<Duration>,
     mut data_ch_rx: mpsc::Receiver<T::Stream>,
     _data_ch_req_tx: mpsc::UnboundedSender<bool>,
     shutdown_rx: broadcast::Receiver<bool>,
@@ -808,21 +844,37 @@ async fn run_socket_stream_connection_pool<T: Transport>(
         socket_stream_listen_and_send(bind_addr, _data_ch_req_tx.clone(), shutdown_rx);
     let cmd = bincode::serialize(&DataChannelCmd::StartForwardSocketStream).unwrap();
 
-    'pool: while let Some(mut visitor) = visitor_rx.recv().await {
+    'pool: while let Some(visitor) = visitor_rx.recv().await {
+        let mut visitor = Some(visitor);
         loop {
             if let Some(mut ch) = data_ch_rx.recv().await {
                 if write_and_flush(&mut ch, &cmd).await.is_ok() {
+                    let v = visitor.take().unwrap();
                     tokio::spawn(async move {
-                        let _ = copy_bidirectional(&mut ch, &mut visitor).await;
+                        if let Err(e) = forward_bidirectional_with_idle_timeout(
+                            ch,
+                            v,
+                            post_half_close_idle_timeout,
+                        )
+                        .await
+                        {
+                            log_forwarder_outcome("socket_stream", &e);
+                        }
                     });
                     break;
                 } else {
-                    // Current data channel is broken. Request for a new one
+                    // Current data channel is broken. Request for a new one.
                     if _data_ch_req_tx.send(true).is_err() {
+                        if let Some(mut v) = visitor.take() {
+                            let _ = AsyncWriteExt::shutdown(&mut v).await;
+                        }
                         break 'pool;
                     }
                 }
             } else {
+                if let Some(mut v) = visitor.take() {
+                    let _ = AsyncWriteExt::shutdown(&mut v).await;
+                }
                 break 'pool;
             }
         }

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -95,16 +95,34 @@ impl Stream for StreamWrapper {
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(Error::other(err)))),
-            Poll::Ready(Some(Ok(res))) => {
-                if let Message::Binary(b) = res {
-                    Poll::Ready(Some(Ok(Bytes::from(b))))
-                } else {
-                    Poll::Ready(Some(Err(Error::new(
-                        ErrorKind::InvalidData,
-                        "unexpected frame",
-                    ))))
-                }
-            }
+            Poll::Ready(Some(Ok(res))) => match res {
+                Message::Binary(b) => Poll::Ready(Some(Ok(Bytes::from(b)))),
+                // The peer sent a Close frame (the WebSocket protocol's
+                // equivalent of TCP FIN). Surface it as a clean stream end
+                // so the bidirectional forwarder treats it as EOF rather
+                // than as a transport error that would tear the reverse
+                // direction down.
+                //
+                // TODO: drive the queued Close reply to completion.
+                // tungstenite queues an outgoing Close reply when it
+                // observes an inbound Close, and that reply is only
+                // flushed when the sibling write half eventually reaches
+                // `poll_close`. If the surviving direction is reaped by
+                // the post-half-close idle timeout instead, the reply is
+                // dropped on `WriteHalf::drop`. The peer then observes an
+                // abnormal close (RFC 6455 §7.1.5) instead of a clean
+                // close-handshake, and any client / proxy that applies a
+                // long WebSocket close-timeout will hold its resources
+                // until that timer fires. This is a protocol-cleanliness
+                // issue, not data loss. Driving `poll_flush` here would
+                // require sharing the inner `WebSocketStream` between
+                // the split halves, which is structural work.
+                Message::Close(_) => Poll::Ready(None),
+                _ => Poll::Ready(Some(Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "unexpected frame",
+                )))),
+            },
         }
     }
 

--- a/tests/for_leak/noise_transport.toml
+++ b/tests/for_leak/noise_transport.toml
@@ -1,0 +1,29 @@
+[client]
+remote_addr = "127.0.0.1:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[client.transport]
+type = "noise"
+[client.transport.noise]
+remote_public_key = "mEnUEACy9UrTBmwoCJb6fcKWBRdvfD9XzuBVsroOLFg="
+
+[client.services.delayed_response]
+local_addr = "127.0.0.1:9080"
+[client.services.sinkhole]
+local_addr = "127.0.0.1:9081"
+
+[server]
+bind_addr = "0.0.0.0:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[server.transport]
+type = "noise"
+[server.transport.noise]
+local_private_key = "kQiSRtS3bs8BoGCJYgFnl1FLrTG1lV53Dj8jSjmg8tE="
+
+[server.services.delayed_response]
+bind_addr = "0.0.0.0:3334"
+[server.services.sinkhole]
+bind_addr = "0.0.0.0:3335"

--- a/tests/for_leak/tcp_transport.toml
+++ b/tests/for_leak/tcp_transport.toml
@@ -1,0 +1,25 @@
+[client]
+remote_addr = "127.0.0.1:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[client.transport]
+type = "tcp"
+
+[client.services.delayed_response]
+local_addr = "127.0.0.1:9080"
+[client.services.sinkhole]
+local_addr = "127.0.0.1:9081"
+
+[server]
+bind_addr = "0.0.0.0:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[server.transport]
+type = "tcp"
+
+[server.services.delayed_response]
+bind_addr = "0.0.0.0:3334"
+[server.services.sinkhole]
+bind_addr = "0.0.0.0:3335"

--- a/tests/for_leak/tls_transport.toml
+++ b/tests/for_leak/tls_transport.toml
@@ -1,0 +1,31 @@
+[client]
+remote_addr = "127.0.0.1:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[client.transport]
+type = "tls"
+[client.transport.tls]
+trusted_root = "examples/tls/rootCA.crt"
+hostname = "localhost"
+
+[client.services.delayed_response]
+local_addr = "127.0.0.1:9080"
+[client.services.sinkhole]
+local_addr = "127.0.0.1:9081"
+
+[server]
+bind_addr = "0.0.0.0:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[server.transport]
+type = "tls"
+[server.transport.tls]
+pkcs12 = "examples/tls/identity.pfx"
+pkcs12_password = "1234"
+
+[server.services.delayed_response]
+bind_addr = "0.0.0.0:3334"
+[server.services.sinkhole]
+bind_addr = "0.0.0.0:3335"

--- a/tests/for_leak/websocket_tls_transport.toml
+++ b/tests/for_leak/websocket_tls_transport.toml
@@ -1,0 +1,35 @@
+[client]
+remote_addr = "127.0.0.1:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[client.transport]
+type = "websocket"
+[client.transport.tls]
+trusted_root = "examples/tls/rootCA.crt"
+hostname = "localhost"
+[client.transport.websocket]
+tls = true
+
+[client.services.delayed_response]
+local_addr = "127.0.0.1:9080"
+[client.services.sinkhole]
+local_addr = "127.0.0.1:9081"
+
+[server]
+bind_addr = "0.0.0.0:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[server.transport]
+type = "websocket"
+[server.transport.tls]
+pkcs12 = "examples/tls/identity.pfx"
+pkcs12_password = "1234"
+[server.transport.websocket]
+tls = true
+
+[server.services.delayed_response]
+bind_addr = "0.0.0.0:3334"
+[server.services.sinkhole]
+bind_addr = "0.0.0.0:3335"

--- a/tests/for_leak/websocket_transport.toml
+++ b/tests/for_leak/websocket_transport.toml
@@ -1,0 +1,29 @@
+[client]
+remote_addr = "127.0.0.1:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[client.transport]
+type = "websocket"
+[client.transport.websocket]
+tls = false
+
+[client.services.delayed_response]
+local_addr = "127.0.0.1:9080"
+[client.services.sinkhole]
+local_addr = "127.0.0.1:9081"
+
+[server]
+bind_addr = "0.0.0.0:3333"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[server.transport]
+type = "websocket"
+[server.transport.websocket]
+tls = false
+
+[server.services.delayed_response]
+bind_addr = "0.0.0.0:3334"
+[server.services.sinkhole]
+bind_addr = "0.0.0.0:3335"

--- a/tests/for_socket_leak/tcp_transport.toml
+++ b/tests/for_socket_leak/tcp_transport.toml
@@ -1,0 +1,29 @@
+[client]
+remote_addr = "127.0.0.1:3343"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[client.transport]
+type = "tcp"
+
+[client.services.delayed_response]
+type = "socket_stream"
+local_addr = "/tmp/rathole_leak_test/delayed_response.sock"
+[client.services.sinkhole]
+type = "socket_stream"
+local_addr = "/tmp/rathole_leak_test/sinkhole.sock"
+
+[server]
+bind_addr = "0.0.0.0:3343"
+default_token = "default_token_if_not_specify"
+post_half_close_idle_timeout = 1 # 1s keeps the 5s stuck-peer assertion fast
+
+[server.transport]
+type = "tcp"
+
+[server.services.delayed_response]
+type = "socket_stream"
+bind_addr = "/tmp/rathole_leak_test/delayed_response_exposed.sock"
+[server.services.sinkhole]
+type = "socket_stream"
+bind_addr = "/tmp/rathole_leak_test/sinkhole_exposed.sock"

--- a/tests/leak_test.rs
+++ b/tests/leak_test.rs
@@ -1,0 +1,406 @@
+//! Regression tests for the two-phase forwarder.
+//!
+//! Two scenarios under one rathole instance:
+//!   1. Half-close-then-respond (correctness): visitor writes, half-closes,
+//!      upstream sees EOF, upstream writes a response, visitor must read it.
+//!      Verifies we did NOT regress what `copy_bidirectional` did right.
+//!   2. Stuck-peer cleanup (leak): visitor half-closes, upstream never
+//!      writes nor closes; the post-half-close idle timeout must reap the
+//!      connection so the visitor's read returns within a bounded time.
+//!
+//! Both scenarios run across every enabled transport, with a separate Unix
+//! socket variant for the `socket_stream` service type.
+
+use anyhow::Result;
+use std::time::Duration;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    sync::broadcast,
+    time::{self, timeout},
+};
+use tracing::info;
+use tracing_subscriber::EnvFilter;
+
+use crate::common::{run_rathole_client, run_rathole_server};
+
+mod common;
+
+// === TCP transports ===
+const DELAYED_RESPONSE_LOCAL: &str = "127.0.0.1:9080";
+const SINKHOLE_LOCAL: &str = "127.0.0.1:9081";
+const DELAYED_RESPONSE_EXPOSED: &str = "127.0.0.1:3334";
+const SINKHOLE_EXPOSED: &str = "127.0.0.1:3335";
+
+// === Unix socket variant (separate config to avoid port collisions) ===
+#[cfg(unix)]
+const SOCK_DELAYED_RESPONSE_LOCAL: &str =
+    "/tmp/rathole_leak_test/delayed_response.sock";
+#[cfg(unix)]
+const SOCK_SINKHOLE_LOCAL: &str = "/tmp/rathole_leak_test/sinkhole.sock";
+#[cfg(unix)]
+const SOCK_DELAYED_RESPONSE_EXPOSED: &str =
+    "/tmp/rathole_leak_test/delayed_response_exposed.sock";
+#[cfg(unix)]
+const SOCK_SINKHOLE_EXPOSED: &str = "/tmp/rathole_leak_test/sinkhole_exposed.sock";
+
+fn init() {
+    let level = "info";
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::from(level)),
+        )
+        .try_init();
+}
+
+/// Local target that reads the request, observes EOF, writes a response, then
+/// closes. This is the half-close-then-respond pattern that
+/// `copy_bidirectional` handles correctly and the broken `select!+copy`
+/// approach destroys.
+async fn delayed_response_server(addr: &'static str) -> Result<()> {
+    let l = TcpListener::bind(addr).await?;
+    loop {
+        let (mut conn, _) = l.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            // Drain request until EOF.
+            loop {
+                match conn.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(_) => continue,
+                    Err(_) => return,
+                }
+            }
+            // Small delay to simulate "compute after EOF" — must not race the
+            // forwarder's idle timeout (which is 1s in the toml).
+            time::sleep(Duration::from_millis(150)).await;
+            let _ = conn.write_all(b"RESP").await;
+            let _ = conn.shutdown().await;
+        });
+    }
+}
+
+/// Local target that drains the request and never closes its own write side.
+/// Triggers the post-half-close idle path.
+async fn sinkhole_server(addr: &'static str) -> Result<()> {
+    let l = TcpListener::bind(addr).await?;
+    loop {
+        let (mut conn, _) = l.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                match conn.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+            time::sleep(Duration::from_secs(120)).await;
+            drop(conn);
+        });
+    }
+}
+
+#[cfg(unix)]
+async fn delayed_response_unix_server(addr: &'static str) -> Result<()> {
+    let _ = std::fs::remove_file(addr);
+    let l = tokio::net::UnixListener::bind(addr)?;
+    loop {
+        let (mut conn, _) = l.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                match conn.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(_) => continue,
+                    Err(_) => return,
+                }
+            }
+            time::sleep(Duration::from_millis(150)).await;
+            let _ = conn.write_all(b"RESP").await;
+            let _ = conn.shutdown().await;
+        });
+    }
+}
+
+#[cfg(unix)]
+async fn sinkhole_unix_server(addr: &'static str) -> Result<()> {
+    let _ = std::fs::remove_file(addr);
+    let l = tokio::net::UnixListener::bind(addr)?;
+    loop {
+        let (mut conn, _) = l.accept().await?;
+        tokio::spawn(async move {
+            let mut buf = [0u8; 4096];
+            loop {
+                match conn.read(&mut buf).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => continue,
+                }
+            }
+            time::sleep(Duration::from_secs(120)).await;
+            drop(conn);
+        });
+    }
+}
+
+#[tokio::test]
+async fn forwarder_regression_across_transports() -> Result<()> {
+    if cfg!(not(all(feature = "client", feature = "server"))) {
+        return Ok(());
+    }
+
+    init();
+
+    tokio::spawn(async move {
+        if let Err(e) = delayed_response_server(DELAYED_RESPONSE_LOCAL).await {
+            panic!("delayed-response server failed: {:?}", e);
+        }
+    });
+    tokio::spawn(async move {
+        if let Err(e) = sinkhole_server(SINKHOLE_LOCAL).await {
+            panic!("sinkhole server failed: {:?}", e);
+        }
+    });
+    time::sleep(Duration::from_millis(200)).await;
+
+    run_for_transport("tests/for_leak/tcp_transport.toml", true).await?;
+
+    #[cfg(any(
+        all(target_os = "macos", feature = "rustls"),
+        all(not(target_os = "macos"), any(feature = "native-tls", feature = "rustls")),
+    ))]
+    run_for_transport("tests/for_leak/tls_transport.toml", true).await?;
+
+    #[cfg(feature = "noise")]
+    run_for_transport("tests/for_leak/noise_transport.toml", true).await?;
+
+    // WebSocket cannot carry a half-close-then-respond pattern because per
+    // RFC 6455 the peer that receives a Close frame must respond with its
+    // own Close, which closes its sending side too — we can still verify
+    // the stuck-peer cleanup path though.
+    #[cfg(any(feature = "websocket-native-tls", feature = "websocket-rustls"))]
+    run_for_transport("tests/for_leak/websocket_transport.toml", false).await?;
+
+    #[cfg(not(target_os = "macos"))]
+    #[cfg(any(feature = "websocket-native-tls", feature = "websocket-rustls"))]
+    run_for_transport("tests/for_leak/websocket_tls_transport.toml", false).await?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn forwarder_regression_unix_socket() -> Result<()> {
+    if cfg!(not(all(feature = "client", feature = "server"))) {
+        return Ok(());
+    }
+
+    init();
+    let _ = std::fs::create_dir_all("/tmp/rathole_leak_test");
+
+    tokio::spawn(async move {
+        if let Err(e) = delayed_response_unix_server(SOCK_DELAYED_RESPONSE_LOCAL).await {
+            panic!("delayed-response unix server failed: {:?}", e);
+        }
+    });
+    tokio::spawn(async move {
+        if let Err(e) = sinkhole_unix_server(SOCK_SINKHOLE_LOCAL).await {
+            panic!("sinkhole unix server failed: {:?}", e);
+        }
+    });
+    time::sleep(Duration::from_millis(200)).await;
+
+    run_unix_for_transport("tests/for_socket_leak/tcp_transport.toml").await?;
+
+    Ok(())
+}
+
+async fn run_for_transport(
+    config_path: &'static str,
+    check_half_close_response: bool,
+) -> Result<()> {
+    info!("forwarder regression for {}", config_path);
+
+    let (client_shutdown_tx, client_shutdown_rx) = broadcast::channel(1);
+    let (server_shutdown_tx, server_shutdown_rx) = broadcast::channel(1);
+
+    let server = tokio::spawn(async move {
+        run_rathole_server(config_path, server_shutdown_rx)
+            .await
+            .unwrap();
+    });
+    time::sleep(Duration::from_millis(500)).await;
+    let client = tokio::spawn(async move {
+        run_rathole_client(config_path, client_shutdown_rx)
+            .await
+            .unwrap();
+    });
+    time::sleep(Duration::from_millis(2500)).await;
+
+    if check_half_close_response {
+        check_half_close_with_response(DELAYED_RESPONSE_EXPOSED).await?;
+    }
+    check_stuck_peer_cleanup_tcp(SINKHOLE_EXPOSED).await?;
+
+    client_shutdown_tx.send(true)?;
+    server_shutdown_tx.send(true)?;
+    let _ = tokio::join!(client, server);
+    time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn run_unix_for_transport(config_path: &'static str) -> Result<()> {
+    info!("unix-socket forwarder regression for {}", config_path);
+
+    // Delete stale exposed sockets from prior runs.
+    let _ = std::fs::remove_file(SOCK_DELAYED_RESPONSE_EXPOSED);
+    let _ = std::fs::remove_file(SOCK_SINKHOLE_EXPOSED);
+
+    let (client_shutdown_tx, client_shutdown_rx) = broadcast::channel(1);
+    let (server_shutdown_tx, server_shutdown_rx) = broadcast::channel(1);
+
+    let server = tokio::spawn(async move {
+        run_rathole_server(config_path, server_shutdown_rx)
+            .await
+            .unwrap();
+    });
+    time::sleep(Duration::from_millis(500)).await;
+    let client = tokio::spawn(async move {
+        run_rathole_client(config_path, client_shutdown_rx)
+            .await
+            .unwrap();
+    });
+    time::sleep(Duration::from_millis(2500)).await;
+
+    check_half_close_with_response_unix(SOCK_DELAYED_RESPONSE_EXPOSED).await?;
+    check_stuck_peer_cleanup_unix(SOCK_SINKHOLE_EXPOSED).await?;
+
+    client_shutdown_tx.send(true)?;
+    server_shutdown_tx.send(true)?;
+    let _ = tokio::join!(client, server);
+    time::sleep(Duration::from_millis(500)).await;
+    Ok(())
+}
+
+/// Visitor sends a request, half-closes, then expects to read a response.
+/// Under the broken `select!+copy` PR this would lose the response. Under the
+/// two-phase forwarder this must succeed.
+async fn check_half_close_with_response(addr: &str) -> Result<()> {
+    info!("check half-close with response (TCP)");
+    let mut conn = connect_with_retry_tcp(addr, Duration::from_secs(15)).await?;
+    conn.write_all(b"REQ").await?;
+    conn.shutdown().await?;
+
+    let mut resp = [0u8; 4];
+    let read = timeout(Duration::from_secs(5), conn.read_exact(&mut resp)).await;
+    let r = read.map_err(|_| {
+        anyhow::anyhow!(
+            "visitor read hung waiting for delayed response \u{2014} forwarder regressed half-close semantics"
+        )
+    })?;
+    r.map_err(|e| anyhow::anyhow!("visitor read errored: {e}"))?;
+    assert_eq!(&resp, b"RESP", "expected RESP after half-close, got {:?}", resp);
+    Ok(())
+}
+
+/// Visitor half-closes; sinkhole upstream never closes its write side. The
+/// post-half-close idle timeout (1s in the toml) must reap the connection so
+/// the visitor sees EOF promptly.
+async fn check_stuck_peer_cleanup_tcp(addr: &str) -> Result<()> {
+    info!("check stuck-peer cleanup (TCP)");
+    let mut conn = connect_with_retry_tcp(addr, Duration::from_secs(15)).await?;
+    conn.write_all(b"hello").await?;
+    conn.shutdown().await?;
+
+    let mut buf = [0u8; 16];
+    let read = timeout(Duration::from_secs(5), conn.read(&mut buf)).await;
+    let n = read
+        .map_err(|_| anyhow::anyhow!("visitor read hung after half-close \u{2014} stuck-peer cleanup regressed"))?
+        .map_err(|e| anyhow::anyhow!("visitor read errored: {e}"))?;
+    assert_eq!(n, 0, "expected EOF after stuck-peer cleanup, got {n} bytes");
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn check_half_close_with_response_unix(addr: &str) -> Result<()> {
+    info!("check half-close with response (unix)");
+    let mut conn = connect_with_retry_unix(addr, Duration::from_secs(15)).await?;
+    conn.write_all(b"REQ").await?;
+    conn.shutdown().await?;
+
+    let mut resp = [0u8; 4];
+    let read = timeout(Duration::from_secs(5), conn.read_exact(&mut resp)).await;
+    let r = read.map_err(|_| {
+        anyhow::anyhow!(
+            "unix visitor read hung waiting for delayed response \u{2014} forwarder regressed half-close semantics"
+        )
+    })?;
+    r.map_err(|e| anyhow::anyhow!("unix visitor read errored: {e}"))?;
+    assert_eq!(&resp, b"RESP", "expected RESP after half-close, got {:?}", resp);
+    Ok(())
+}
+
+#[cfg(unix)]
+async fn check_stuck_peer_cleanup_unix(addr: &str) -> Result<()> {
+    info!("check stuck-peer cleanup (unix)");
+    let mut conn = connect_with_retry_unix(addr, Duration::from_secs(15)).await?;
+    conn.write_all(b"hello").await?;
+    conn.shutdown().await?;
+
+    let mut buf = [0u8; 16];
+    let read = timeout(Duration::from_secs(5), conn.read(&mut buf)).await;
+    let n = read
+        .map_err(|_| anyhow::anyhow!("unix visitor read hung after half-close \u{2014} stuck-peer cleanup regressed"))?
+        .map_err(|e| anyhow::anyhow!("unix visitor read errored: {e}"))?;
+    assert_eq!(n, 0, "expected EOF after stuck-peer cleanup, got {n} bytes");
+    Ok(())
+}
+
+/// Connect with retry — the service listener on the rathole server side is
+/// only bound after the client's control-channel handshake completes. On slow
+/// runners a single connect attempt races the handshake.
+async fn connect_with_retry_tcp(addr: &str, total: Duration) -> Result<TcpStream> {
+    let deadline = tokio::time::Instant::now() + total;
+    let mut last_err = None;
+    while tokio::time::Instant::now() < deadline {
+        match TcpStream::connect(addr).await {
+            Ok(c) => return Ok(c),
+            Err(e) => {
+                last_err = Some(e);
+                time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(anyhow::anyhow!(
+        "failed to connect to {addr} within {:?}: {}",
+        total,
+        last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "no error".into())
+    ))
+}
+
+#[cfg(unix)]
+async fn connect_with_retry_unix(
+    addr: &str,
+    total: Duration,
+) -> Result<tokio::net::UnixStream> {
+    let deadline = tokio::time::Instant::now() + total;
+    let mut last_err = None;
+    while tokio::time::Instant::now() < deadline {
+        match tokio::net::UnixStream::connect(addr).await {
+            Ok(c) => return Ok(c),
+            Err(e) => {
+                last_err = Some(e);
+                time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+    Err(anyhow::anyhow!(
+        "failed to connect to {addr} within {:?}: {}",
+        total,
+        last_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "no error".into())
+    ))
+}


### PR DESCRIPTION
Connection leak

copy_bidirectional uses TCP half-close: when one side sends FIN, it shuts down the write side of the other stream but waits indefinitely for the reverse direction to also finish. If the remote end (e.g. xray SS-2022) never closes its side after receiving a half-close, both the visitor (CLOSE-WAIT) and data channel (FIN-WAIT-2) connections leak permanently.

Replace with tokio::select! over two io::copy tasks. When either direction finishes (EOF or error), both write sides are immediately shut down and the cancelled copy task is dropped, ensuring full connection cleanup regardless of peer behavior.

Also explicitly shutdown unforwarded visitors in the server connection pool when data channels are unavailable.