### PR TITLE
feat(client): per-service remote_addr for multi-server setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Here is the full configuration specification:
 
 ```toml
 [client]
-remote_addr = "example.com:2333" # Necessary. The address of the server
+remote_addr = "example.com:2333" # Optional. The default address of the server. Required unless every service overrides it via `[client.services.<name>].remote_addr`. See `examples/multi_server` for the multi-server pattern.
 default_token = "default_token_if_not_specify" # Optional. The default token of services, if they don't define their own ones
 heartbeat_timeout = 40 # Optional. Set to 0 to disable the application-layer heartbeat test. The value must be greater than `server.heartbeat_interval`. Default: 40 seconds
 retry_interval = 1 # Optional. The interval between retry to connect to the server. Default: 1 second
@@ -135,6 +135,7 @@ tls = true # If `true` then it will use settings in `client.transport.tls`
 type = "tcp" # Optional. The protocol that needs forwarding. Possible values: ["tcp", "udp", "socket_stream"]. Default: "tcp"
 token = "whatever" # Necessary if `client.default_token` not set
 local_addr = "127.0.0.1:1081" # Necessary. The address of the service that needs to be forwarded
+remote_addr = "alt.example.com:2333" # Optional. Override `client.remote_addr` for this one service. Useful when a single client tunnels different services to different servers. The transport block (TLS / Noise / WebSocket) is shared across services, so all overridden servers must accept the same transport configuration.
 nodelay = true # Optional. Override the `client.transport.nodelay` per service
 retry_interval = 1 # Optional. The interval between retry to connect to the server. Default: inherits the global config
 

--- a/examples/multi_server/client.toml
+++ b/examples/multi_server/client.toml
@@ -1,0 +1,27 @@
+# A single rathole client tunneling different services to different servers.
+#
+# `[client].remote_addr` is the default — services that don't override it
+# will use it. Each service can also set its own `remote_addr`, in which
+# case that service's control + data channels go to that specific server.
+#
+# All services share the same `[client.transport]` block (and any
+# transport-level credentials), so every reachable server must speak the
+# same transport protocol.
+
+[client]
+remote_addr = "primary.example.com:2333"   # default for services that don't override
+default_token = "123"
+
+# Forwarded through the default `primary.example.com` server.
+[client.services.svc_primary]
+local_addr = "127.0.0.1:8080"
+
+# Forwarded through a different server in another region.
+[client.services.svc_eu]
+remote_addr = "eu.example.com:2333"
+local_addr = "127.0.0.1:8081"
+
+# Yet another server, no global default needed for this service.
+[client.services.svc_us]
+remote_addr = "us.example.com:2333"
+local_addr = "127.0.0.1:8082"

--- a/examples/multi_server/server.toml
+++ b/examples/multi_server/server.toml
@@ -1,0 +1,11 @@
+# Each rathole server hosts only the services it is responsible for. The
+# client config in `client.toml` points each service at one of these
+# servers via its own `remote_addr`. Service names must match exactly
+# between the client and the corresponding server.
+
+[server]
+bind_addr = "0.0.0.0:2333"
+default_token = "123"
+
+[server.services.svc_primary]
+bind_addr = "0.0.0.0:5202"

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,9 +110,13 @@ impl<T: 'static + Transport> Client<T> {
     ) -> Result<()> {
         for (name, config) in &self.config.services {
             // Create a control channel for each service defined
+            let remote_addr = config
+                .remote_addr
+                .clone()
+                .expect("remote_addr resolved by Config::validate_client_config");
             let handle = ControlChannelHandle::new(
                 (*config).clone(),
-                self.config.remote_addr.clone(),
+                remote_addr,
                 self.transport.clone(),
                 self.config.heartbeat_timeout,
             );
@@ -152,9 +156,13 @@ impl<T: 'static + Transport> Client<T> {
             ConfigChange::ClientChange(client_change) => match client_change {
                 ClientServiceChange::Add(cfg) => {
                     let name = cfg.name.clone();
+                    let remote_addr = cfg
+                        .remote_addr
+                        .clone()
+                        .expect("remote_addr resolved by Config::validate_client_config");
                     let handle = ControlChannelHandle::new(
                         cfg,
-                        self.config.remote_addr.clone(),
+                        remote_addr,
                         self.transport.clone(),
                         self.config.heartbeat_timeout,
                     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,7 @@ pub struct ClientServiceConfig {
     #[serde(skip)]
     pub name: String,
     pub local_addr: String,
+    pub remote_addr: Option<String>,
     #[serde(default)] // Default to false
     pub prefer_ipv6: bool,
     pub token: Option<MaskedString>,
@@ -241,7 +242,7 @@ fn default_client_retry_interval() -> u64 {
 #[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct ClientConfig {
-    pub remote_addr: String,
+    pub remote_addr: Option<String>,
     pub default_token: Option<MaskedString>,
     pub prefer_ipv6: Option<bool>,
     pub services: HashMap<String, ClientServiceConfig>,
@@ -324,6 +325,15 @@ impl Config {
             }
             if s.retry_interval.is_none() {
                 s.retry_interval = Some(client.retry_interval);
+            }
+            if s.remote_addr.is_none() {
+                s.remote_addr = client.remote_addr.clone();
+            }
+            if s.remote_addr.is_none() {
+                bail!(
+                    "The remote_addr of service {} is not set, and no global client.remote_addr is configured",
+                    name
+                );
             }
         }
 
@@ -486,7 +496,10 @@ mod tests {
 
     #[test]
     fn test_validate_client_config() -> Result<()> {
-        let mut cfg = ClientConfig::default();
+        let mut cfg = ClientConfig {
+            remote_addr: Some("example.com:2333".into()),
+            ..Default::default()
+        };
 
         cfg.services.insert(
             "foo1".into(),
@@ -530,6 +543,137 @@ mod tests {
                 .unwrap()
                 .0,
             "4"
+        );
+
+        // Service inherits the global remote_addr
+        assert_eq!(
+            cfg.services
+                .get("foo1")
+                .unwrap()
+                .remote_addr
+                .as_deref(),
+            Some("example.com:2333"),
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_client_config_per_service_remote_addr() -> Result<()> {
+        // No global remote_addr, but every service supplies its own — must validate.
+        let mut cfg = ClientConfig {
+            remote_addr: None,
+            default_token: Some("t".into()),
+            ..Default::default()
+        };
+        cfg.services.insert(
+            "a".into(),
+            ClientServiceConfig {
+                name: "a".into(),
+                local_addr: "127.0.0.1:80".into(),
+                remote_addr: Some("a.example.com:2333".into()),
+                ..Default::default()
+            },
+        );
+        cfg.services.insert(
+            "b".into(),
+            ClientServiceConfig {
+                name: "b".into(),
+                local_addr: "127.0.0.1:81".into(),
+                remote_addr: Some("b.example.com:2333".into()),
+                ..Default::default()
+            },
+        );
+        Config::validate_client_config(&mut cfg)?;
+        assert_eq!(
+            cfg.services.get("a").unwrap().remote_addr.as_deref(),
+            Some("a.example.com:2333"),
+        );
+        assert_eq!(
+            cfg.services.get("b").unwrap().remote_addr.as_deref(),
+            Some("b.example.com:2333"),
+        );
+
+        // Neither global nor per-service remote_addr — must fail.
+        let mut cfg = ClientConfig {
+            remote_addr: None,
+            default_token: Some("t".into()),
+            ..Default::default()
+        };
+        cfg.services.insert(
+            "a".into(),
+            ClientServiceConfig {
+                name: "a".into(),
+                local_addr: "127.0.0.1:80".into(),
+                remote_addr: None,
+                ..Default::default()
+            },
+        );
+        assert!(Config::validate_client_config(&mut cfg).is_err());
+
+        // Global set + per-service override → service must keep its own value
+        // (the override is preserved, not clobbered by the fallback).
+        let mut cfg = ClientConfig {
+            remote_addr: Some("global.example.com:2333".into()),
+            default_token: Some("t".into()),
+            ..Default::default()
+        };
+        cfg.services.insert(
+            "override".into(),
+            ClientServiceConfig {
+                name: "override".into(),
+                local_addr: "127.0.0.1:80".into(),
+                remote_addr: Some("override.example.com:2333".into()),
+                ..Default::default()
+            },
+        );
+        cfg.services.insert(
+            "inherit".into(),
+            ClientServiceConfig {
+                name: "inherit".into(),
+                local_addr: "127.0.0.1:81".into(),
+                remote_addr: None,
+                ..Default::default()
+            },
+        );
+        Config::validate_client_config(&mut cfg)?;
+        assert_eq!(
+            cfg.services.get("override").unwrap().remote_addr.as_deref(),
+            Some("override.example.com:2333"),
+            "per-service remote_addr must win over global",
+        );
+        assert_eq!(
+            cfg.services.get("inherit").unwrap().remote_addr.as_deref(),
+            Some("global.example.com:2333"),
+            "service without override must inherit global remote_addr",
+        );
+
+        // Token AND remote_addr both missing — token validation runs first
+        // so the token error is what surfaces. Lock that order in to catch
+        // accidental reordering of the validator.
+        let mut cfg = ClientConfig {
+            remote_addr: None,
+            default_token: None,
+            ..Default::default()
+        };
+        cfg.services.insert(
+            "broken".into(),
+            ClientServiceConfig {
+                name: "broken".into(),
+                local_addr: "127.0.0.1:80".into(),
+                token: None,
+                remote_addr: None,
+                ..Default::default()
+            },
+        );
+        let err = Config::validate_client_config(&mut cfg).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("token"),
+            "expected token error first, got {msg:?}"
+        );
+        assert!(
+            !msg.contains("remote_addr"),
+            "remote_addr error must not surface when token is also missing, got {msg:?}"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary

- Makes `[client].remote_addr` optional and adds an optional `[client.services.<name>].remote_addr` override, so a single rathole client process can tunnel different services to different servers.
- The validator falls back to the global `[client].remote_addr` when the per-service override is missing, and bails at parse time if both are absent for a service (instead of silently turning into the empty string and failing later at TCP connect).
- Pre-existing single-server configs (`[client].remote_addr = "..."` set, no per-service field) keep working unchanged.

## Why

I run a single rathole client that needs to expose some services through one server and other services through another (different geographical regions, redundancy). Previously this required running multiple rathole client processes, each with its own config file, each holding its own state. Per-service `remote_addr` collapses that into one process.

## Behavior

- If a service config sets `remote_addr`, that value is used for that service's control channel and data channels.
- Otherwise the global `[client].remote_addr` is inherited.
- If neither is set for a service, parsing fails with `The remote_addr of service <name> is not set, and no global client.remote_addr is configured`.
- The transport block (`[client.transport]`, including TLS / Noise / WebSocket settings) is shared across all services. So every server reachable via per-service overrides must accept the same transport configuration.

## Example

```toml
[client]
remote_addr = "primary.example.com:2333"   # default for services without override
default_token = "shared"

[client.services.svc_primary]
local_addr = "127.0.0.1:8080"              # uses the global remote_addr

[client.services.svc_eu]
remote_addr = "eu.example.com:2333"
local_addr  = "127.0.0.1:8081"

[client.services.svc_us]
remote_addr = "us.example.com:2333"
local_addr  = "127.0.0.1:8082"
```

A backwards-compatible single-server config still works:

```toml
[client]
remote_addr   = "example.com:2333"
default_token = "shared"

[client.services.svc1]
local_addr = "127.0.0.1:8080"   # uses the global remote_addr
```

A runnable example pair lives at `examples/multi_server/`.

## Hot reload

`[client.services.<name>].remote_addr` edits propagate through `ClientServiceChange::Add` / `Delete` and reconnect just that service. Editing the top-level `[client].remote_addr` is treated as a `General` config change and restarts the running instance, the same way other `[client]`-level fields behave today.

## Tests

- `config::tests::test_validate_client_config` (existing test, updated to assert the inheritance path).
- `config::tests::test_client_config_per_service_remote_addr` (new): covers
  - every service supplying its own `remote_addr` with no global one,
  - both global and per-service set → per-service wins,
  - service inheriting the global,
  - neither set → fail,
  - token + remote_addr both missing → token error surfaces first (locks validator order).
- All existing config / lib / integration tests still pass.

## Test plan

- [x] `cargo build`
- [x] `cargo test --lib` (16/16 passing)
- [x] `cargo test --test integration_test` (3/3 passing)
- [x] `cargo clippy -- -D warnings` clean

## API change disclosure

`ClientConfig.remote_addr: String → Option<String>`. `Config` is `pub use` from the crate root, so this is technically observable to anyone using rathole as a library (the binary is unaffected). Source-level breakage is limited to direct field reads of `client.remote_addr` outside this crate; the validator preserves the runtime semantics for any TOML-driven path.

## Notes

This was split out from PR #460 at the reviewer's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)