### PR TITLE
ci: split and harden Rust checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,71 +2,146 @@ name: Rust
 
 on:
   pull_request:
-    branches: ["*"]
   push:
-    branches: ["main", "dev"]
+    branches: [main, dev]
+  workflow_dispatch:
 
 concurrency:
-  # Documentation suggests ${{ github.head_ref }}, but that's only available on pull_request/pull_request_target triggers, so using ${{ github.ref }}.
-  # On main, we want all builds to complete even if merging happens faster to make it easier to discover at which point something broke.
   group: ${{ github.ref == 'refs/heads/main' && format('ci-main-{0}', github.sha) || format('ci-{0}', github.ref) }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
 
 jobs:
-  lints:
-    name: Lints
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Clippy
-        run: cargo clippy -- -D warnings
-      - name: Setup cargo-hack
-        run: cargo install cargo-hack
-      - name: Check all features
-        run: >
-          cargo hack check --feature-powerset --no-dev-deps --exclude-no-default-features
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+          rustflags: ""
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy with default features
+        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Clippy with rustls features
+        run: >-
+          cargo clippy --locked --all-targets --no-default-features
+          --features server,client,rustls,noise,websocket-rustls,hot-reload,console
+          -- -D warnings
+
+  features:
+    name: Feature combinations (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ["1.92.0", stable]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          rustflags: ""
+      - name: Install cargo-hack 0.6.45
+        run: cargo install cargo-hack --version 0.6.45 --locked
+      - name: Check supported feature combinations
+        run: >-
+          cargo hack check --feature-powerset --no-dev-deps
           --mutually-exclusive-features native-tls,rustls
           --mutually-exclusive-features websocket-native-tls,websocket-rustls
-          --at-least-one-of native-tls,rustls
           --at-least-one-of client,server
 
-
-
-  build:
-    name: Build for ${{ matrix.target }}
-    runs-on: ${{ matrix.os }}
+  unit:
+    name: Unit (${{ matrix.toolchain }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
+      matrix:
+        toolchain: ["1.92.0", stable]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          rustflags: ""
+      - name: Unit tests with default features
+        run: cargo test --locked --lib --bins
+      - name: Unit tests with rustls
+        run: >-
+          cargo test --locked --lib --bins --no-default-features
+          --features server,client,rustls,noise,websocket-rustls,hot-reload
+      - name: Documentation tests
+        run: cargo test --locked --doc
+
+  integration:
+    name: Integration (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            exe: rathole
+          - name: linux-x86_64
+            os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            exe: rathole.exe
+          - name: windows-x86_64
+            os: windows-latest
             target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            exe: rathole
+          - name: macos-x86_64
+            os: macos-15-intel
             target: x86_64-apple-darwin
-          - os: macos-latest
-            exe: rathole
+          - name: macos-arm64
+            os: macos-15
             target: aarch64-apple-darwin
-
+    env:
+      RUST_LOG: "off"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
+          toolchain: stable
+          target: ${{ matrix.target }}
           rustflags: ""
       - name: Build
-        run: cargo build
-      - name: Run tests with native-tls
-        run: cargo test --verbose
-      - name: Run tests with rustls
-        run: cargo test --verbose --no-default-features --features server,client,rustls,noise,websocket-rustls,hot-reload
-      - uses: actions/upload-artifact@v4
-        with:
-          name: rathole-${{ matrix.target }}
-          path: target/debug/${{ matrix.exe }}
+        run: cargo build --locked --target ${{ matrix.target }}
+      - name: Integration tests with native-tls
+        run: cargo test --locked --target ${{ matrix.target }} --test integration_test
+      - name: Integration tests with rustls
+        run: >-
+          cargo test --locked --target ${{ matrix.target }} --test integration_test
+          --no-default-features
+          --features server,client,rustls,noise,websocket-rustls,hot-reload
+
+  required:
+    name: Required checks
+    if: ${{ always() }}
+    needs: [lint, features, unit, integration]
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Verify required jobs
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          FEATURES_RESULT: ${{ needs.features.result }}
+          UNIT_RESULT: ${{ needs.unit.result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+        run: |
+          if [[ "${LINT_RESULT}" != "success" ||
+                "${FEATURES_RESULT}" != "success" ||
+                "${UNIT_RESULT}" != "success" ||
+                "${INTEGRATION_RESULT}" != "success" ]]; then
+            echo "::error::Required job failed: lint=${LINT_RESULT}, features=${FEATURES_RESULT}, unit=${UNIT_RESULT}, integration=${INTEGRATION_RESULT}"
+            exit 1
+          fi

--- a/src/client.rs
+++ b/src/client.rs
@@ -194,7 +194,7 @@ async fn do_data_channel_handshake<T: Transport>(
             args.connector
                 .connect(&args.remote_addr)
                 .await
-                .with_context(|| format!("Failed to connect to {}", &args.remote_addr))
+                .with_context(|| format!("Failed to connect to {}", args.remote_addr))
                 .map_err(backoff::Error::transient)
         },
         |e, duration| {
@@ -438,7 +438,7 @@ impl<T: 'static + Transport> ControlChannel<T> {
             .transport
             .connect(&remote_addr)
             .await
-            .with_context(|| format!("Failed to connect to {}", &self.remote_addr))?;
+            .with_context(|| format!("Failed to connect to {}", self.remote_addr))?;
         T::hint(&conn, SocketOpts::for_control_channel());
 
         // Send hello

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,8 @@ fn genkey(curve: Option<KeypairType>) -> Result<()> {
 }
 
 pub async fn run(args: Cli, shutdown_rx: broadcast::Receiver<bool>) -> Result<()> {
-    if args.genkey.is_some() {
-        return genkey(args.genkey.unwrap());
+    if let Some(curve) = args.genkey {
+        return genkey(curve);
     }
 
     // Raise `nofile` limit on linux and mac

--- a/src/transport/rustls.rs
+++ b/src/transport/rustls.rs
@@ -181,7 +181,7 @@ impl Transport for TlsTransport {
 }
 
 pub(crate) fn get_tcpstream(s: &TlsStream<TcpStream>) -> &TcpStream {
-    &s.get_ref().0
+    s.get_ref().0
 }
 
 #[cfg(test)]

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -27,7 +27,7 @@ use url::Url;
 #[derive(Debug)]
 enum TransportStream {
     Insecure(TcpStream),
-    Secure(TlsStream<TcpStream>),
+    Secure(Box<TlsStream<TcpStream>>),
 }
 
 impl TransportStream {
@@ -223,7 +223,7 @@ impl Transport for WebsocketTransport {
     async fn handshake(&self, conn: Self::RawStream) -> anyhow::Result<Self::Stream> {
         let tsream = match &self.sub {
             SubTransport::Insecure(t) => TransportStream::Insecure(t.handshake(conn).await?),
-            SubTransport::Secure(t) => TransportStream::Secure(t.handshake(conn).await?),
+            SubTransport::Secure(t) => TransportStream::Secure(Box::new(t.handshake(conn).await?)),
         };
         let wsstream = accept_async_with_config(tsream, Some(self.conf)).await?;
         let tun = WebsocketTunnel {
@@ -233,11 +233,11 @@ impl Transport for WebsocketTransport {
     }
 
     async fn connect(&self, addr: &AddrMaybeCached) -> anyhow::Result<Self::Stream> {
-        let u = format!("ws://{}", &addr.addr.as_str());
+        let u = format!("ws://{}", addr.addr.as_str());
         let url = Url::parse(&u).unwrap();
         let tstream = match &self.sub {
             SubTransport::Insecure(t) => TransportStream::Insecure(t.connect(addr).await?),
-            SubTransport::Secure(t) => TransportStream::Secure(t.connect(addr).await?),
+            SubTransport::Secure(t) => TransportStream::Secure(Box::new(t.connect(addr).await?)),
         };
         let (wsstream, _) = client_async_with_config(url, tstream, Some(self.conf))
             .await


### PR DESCRIPTION
Splits Rust CI into lint, feature, unit, integration, and aggregate jobs. Pins tooling and covers Rust 1.92/stable across Linux, Windows, Intel macOS, and ARM macOS.