### PR TITLE
Validate secure WebSocket TLS setup

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@ use crate::protocol::{
     self, read_ack, read_control_cmd, read_data_cmd, read_hello, Ack, Auth, ControlChannelCmd,
     DataChannelCmd, UdpTraffic, CURRENT_PROTO_VERSION, HASH_WIDTH_IN_BYTES,
 };
-use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport};
+use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport, TransportRole};
 use anyhow::{anyhow, bail, Context, Result};
 use backoff::backoff::Backoff;
 use backoff::future::retry_notify;
@@ -93,8 +93,10 @@ struct Client<T: Transport> {
 impl<T: 'static + Transport> Client<T> {
     // Create a Client from `[client]` config block
     async fn from(config: ClientConfig) -> Result<Client<T>> {
-        let transport =
-            Arc::new(T::new(&config.transport).with_context(|| "Failed to create the transport")?);
+        let transport = Arc::new(
+            T::new(&config.transport, TransportRole::Client)
+                .with_context(|| "Failed to create the transport")?,
+        );
         Ok(Client {
             config,
             service_handles: HashMap::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -344,26 +344,40 @@ impl Config {
             })?;
         match config.transport_type {
             TransportType::Tcp => Ok(()),
-            TransportType::Tls => {
-                let tls_config = config
-                    .tls
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("Missing TLS configuration"))?;
-                if is_server {
-                    tls_config
-                        .pkcs12
-                        .as_ref()
-                        .and(tls_config.pkcs12_password.as_ref())
-                        .ok_or_else(|| anyhow!("Missing `pkcs12` or `pkcs12_password`"))?;
-                }
-                Ok(())
-            }
+            TransportType::Tls => Config::validate_tls_config(config, is_server),
             TransportType::Noise => {
                 // The check is done in transport
                 Ok(())
             }
-            TransportType::Websocket => Ok(()),
+            TransportType::Websocket => {
+                let websocket_config = config
+                    .websocket
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("Missing WebSocket configuration"))?;
+                if websocket_config.tls {
+                    Config::validate_tls_config(config, is_server)?;
+                }
+                Ok(())
+            }
         }
+    }
+
+    fn validate_tls_config(config: &TransportConfig, is_server: bool) -> Result<()> {
+        let tls_config = config
+            .tls
+            .as_ref()
+            .ok_or_else(|| anyhow!("Missing TLS configuration"))?;
+        if is_server {
+            tls_config
+                .pkcs12
+                .as_ref()
+                .ok_or_else(|| anyhow!("Missing `tls.pkcs12`"))?;
+            tls_config
+                .pkcs12_password
+                .as_ref()
+                .ok_or_else(|| anyhow!("Missing `tls.pkcs12_password`"))?;
+        }
+        Ok(())
     }
 
     pub async fn from_file(path: &Path) -> Result<Config> {
@@ -432,6 +446,50 @@ mod tests {
             assert!(Config::from_str(&s).is_err());
         }
         Ok(())
+    }
+
+    fn websocket_transport(tls: bool, tls_config: Option<TlsConfig>) -> TransportConfig {
+        TransportConfig {
+            transport_type: TransportType::Websocket,
+            tls: tls_config,
+            websocket: Some(WebsocketConfig { tls }),
+            ..Default::default()
+        }
+    }
+
+    fn server_tls_config(pkcs12: Option<&str>, pkcs12_password: Option<&str>) -> TlsConfig {
+        TlsConfig {
+            hostname: None,
+            trusted_root: None,
+            pkcs12: pkcs12.map(str::to_owned),
+            pkcs12_password: pkcs12_password.map(MaskedString::from),
+        }
+    }
+
+    #[test]
+    fn secure_websocket_requires_role_appropriate_tls_config() {
+        let missing_tls = websocket_transport(true, None);
+        assert!(Config::validate_transport_config(&missing_tls, false).is_err());
+        assert!(Config::validate_transport_config(&missing_tls, true).is_err());
+
+        let missing_identity =
+            websocket_transport(true, Some(server_tls_config(None, Some("password"))));
+        let error = Config::validate_transport_config(&missing_identity, true)
+            .expect_err("secure WebSocket server must have an identity");
+        assert!(error.to_string().contains("tls.pkcs12"));
+
+        let missing_password =
+            websocket_transport(true, Some(server_tls_config(Some("identity.p12"), None)));
+        let error = Config::validate_transport_config(&missing_password, true)
+            .expect_err("secure WebSocket server must have an identity password");
+        assert!(error.to_string().contains("tls.pkcs12_password"));
+
+        let client_system_roots = websocket_transport(true, Some(server_tls_config(None, None)));
+        assert!(Config::validate_transport_config(&client_system_roots, false).is_ok());
+
+        let insecure = websocket_transport(false, None);
+        assert!(Config::validate_transport_config(&insecure, false).is_ok());
+        assert!(Config::validate_transport_config(&insecure, true).is_ok());
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,7 +8,7 @@ use crate::protocol::{
     self, read_auth, read_hello, Ack, ControlChannelCmd, DataChannelCmd, Hello, UdpTraffic,
     HASH_WIDTH_IN_BYTES,
 };
-use crate::transport::{SocketOpts, TcpTransport, Transport};
+use crate::transport::{SocketOpts, TcpTransport, Transport, TransportRole};
 use anyhow::{anyhow, bail, Context, Result};
 use backoff::backoff::Backoff;
 use backoff::ExponentialBackoff;
@@ -129,7 +129,7 @@ impl<T: 'static + Transport> Server<T> {
         let config = Arc::new(config);
         let services = Arc::new(RwLock::new(generate_service_hashmap(&config)));
         let control_channels = Arc::new(RwLock::new(ControlChannelMap::new()));
-        let transport = Arc::new(T::new(&config.transport)?);
+        let transport = Arc::new(T::new(&config.transport, TransportRole::Server)?);
         Ok(Server {
             config,
             services,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -14,6 +14,12 @@ pub const DEFAULT_NODELAY: bool = true;
 pub const DEFAULT_KEEPALIVE_SECS: u64 = 20;
 pub const DEFAULT_KEEPALIVE_INTERVAL: u64 = 8;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportRole {
+    Client,
+    Server,
+}
+
 #[derive(Clone)]
 pub struct AddrMaybeCached {
     pub addr: String,
@@ -55,7 +61,7 @@ pub trait Transport: Debug + Send + Sync {
     type RawStream: Send + Sync;
     type Stream: 'static + AsyncRead + AsyncWrite + Unpin + Send + Sync + Debug;
 
-    fn new(config: &TransportConfig) -> Result<Self>
+    fn new(config: &TransportConfig, role: TransportRole) -> Result<Self>
     where
         Self: Sized;
     /// Provide the transport with socket options, which can be handled at the need of the transport

--- a/src/transport/native_tls.rs
+++ b/src/transport/native_tls.rs
@@ -1,6 +1,6 @@
 use crate::config::{TlsConfig, TransportConfig};
 use crate::helper::host_port_pair;
-use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport};
+use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport, TransportRole};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use std::fs;
@@ -14,8 +14,13 @@ use tokio_native_tls::{TlsAcceptor, TlsConnector};
 pub struct TlsTransport {
     tcp: TcpTransport,
     config: TlsConfig,
-    connector: Option<TlsConnector>,
-    tls_acceptor: Option<TlsAcceptor>,
+    endpoint: TlsEndpoint,
+}
+
+#[derive(Debug)]
+enum TlsEndpoint {
+    Client(TlsConnector),
+    Server(TlsAcceptor),
 }
 
 #[async_trait]
@@ -24,51 +29,55 @@ impl Transport for TlsTransport {
     type RawStream = TcpStream;
     type Stream = TlsStream<TcpStream>;
 
-    fn new(config: &TransportConfig) -> Result<Self> {
-        let tcp = TcpTransport::new(config)?;
+    fn new(config: &TransportConfig, role: TransportRole) -> Result<Self> {
+        let tcp = TcpTransport::new(config, role)?;
         let config = config
             .tls
             .as_ref()
             .ok_or_else(|| anyhow!("Missing tls config"))?;
 
-        let connector = match config.trusted_root.as_ref() {
-            Some(path) => {
-                let s = fs::read_to_string(path)
-                    .with_context(|| "Failed to read the `tls.trusted_root`")?;
-                let cert = Certificate::from_pem(s.as_bytes())
-                    .with_context(|| "Failed to read certificate from `tls.trusted_root`")?;
-                let connector = native_tls::TlsConnector::builder()
-                    .add_root_certificate(cert)
-                    .build()?;
-                Some(TlsConnector::from(connector))
+        let endpoint = match role {
+            TransportRole::Client => {
+                let connector = match config.trusted_root.as_ref() {
+                    Some(path) => {
+                        let s = fs::read_to_string(path)
+                            .with_context(|| "Failed to read the `tls.trusted_root`")?;
+                        let cert = Certificate::from_pem(s.as_bytes()).with_context(|| {
+                            "Failed to read certificate from `tls.trusted_root`"
+                        })?;
+                        native_tls::TlsConnector::builder()
+                            .add_root_certificate(cert)
+                            .build()
+                            .context("Failed to create TLS connector")?
+                    }
+                    None => {
+                        // If no trusted_root is specified, use the system defaults.
+                        native_tls::TlsConnector::builder()
+                            .build()
+                            .context("Failed to create TLS connector from system roots")?
+                    }
+                };
+                TlsEndpoint::Client(TlsConnector::from(connector))
             }
-            None => {
-                // if no trusted_root is specified, allow TlsConnector to use system default
-                let connector = native_tls::TlsConnector::builder().build()?;
-                Some(TlsConnector::from(connector))
-            }
-        };
-
-        let tls_acceptor = match config.pkcs12.as_ref() {
-            Some(path) => {
+            TransportRole::Server => {
+                let path = config.pkcs12.as_ref().context("Missing `tls.pkcs12`")?;
                 let password = config
                     .pkcs12_password
                     .as_ref()
                     .context("Missing `tls.pkcs12_password`")?;
-                let ident = Identity::from_pkcs12(&fs::read(path)?, password)
+                let identity = fs::read(path).context("Failed to read `tls.pkcs12`")?;
+                let ident = Identity::from_pkcs12(&identity, password)
                     .with_context(|| "Failed to create identity")?;
-                Some(TlsAcceptor::from(
+                TlsEndpoint::Server(TlsAcceptor::from(
                     native_tls::TlsAcceptor::new(ident).context("Failed to create TLS acceptor")?,
                 ))
             }
-            None => None,
         };
 
         Ok(TlsTransport {
             tcp,
             config: config.clone(),
-            connector,
-            tls_acceptor,
+            endpoint,
         })
     }
 
@@ -91,14 +100,32 @@ impl Transport for TlsTransport {
     }
 
     async fn handshake(&self, conn: Self::RawStream) -> Result<Self::Stream> {
-        let conn = self.tls_acceptor.as_ref().unwrap().accept(conn).await?;
+        let acceptor = match &self.endpoint {
+            TlsEndpoint::Server(acceptor) => acceptor,
+            TlsEndpoint::Client(_) => {
+                return Err(anyhow!(
+                    "Client TLS transport cannot perform a server handshake"
+                ));
+            }
+        };
+        let conn = acceptor
+            .accept(conn)
+            .await
+            .context("Failed to accept TLS connection")?;
         Ok(conn)
     }
 
     async fn connect(&self, addr: &AddrMaybeCached) -> Result<Self::Stream> {
+        let connector = match &self.endpoint {
+            TlsEndpoint::Client(connector) => connector,
+            TlsEndpoint::Server(_) => {
+                return Err(anyhow!(
+                    "Server TLS transport cannot perform a client connection"
+                ));
+            }
+        };
         let conn = self.tcp.connect(addr).await?;
 
-        let connector = self.connector.as_ref().unwrap();
         Ok(connector
             .connect(
                 self.config
@@ -138,7 +165,7 @@ mod tests {
     #[test]
     fn missing_identity_password_returns_error() -> Result<()> {
         let identity = tempfile::NamedTempFile::new()?;
-        let result = TlsTransport::new(&server_transport(identity.path()));
+        let result = TlsTransport::new(&server_transport(identity.path()), TransportRole::Server);
 
         let error = result.expect_err("missing PKCS#12 password should fail");
         assert!(error.to_string().contains("tls.pkcs12_password"));

--- a/src/transport/noise.rs
+++ b/src/transport/noise.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use super::{AddrMaybeCached, SocketOpts, TcpTransport, Transport};
+use super::{AddrMaybeCached, SocketOpts, TcpTransport, Transport, TransportRole};
 use crate::config::{NoiseConfig, TransportConfig};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -37,8 +37,8 @@ impl Transport for NoiseTransport {
     type RawStream = TcpStream;
     type Stream = snowstorm::stream::NoiseStream<TcpStream>;
 
-    fn new(config: &TransportConfig) -> Result<Self> {
-        let tcp = TcpTransport::new(config)?;
+    fn new(config: &TransportConfig, role: TransportRole) -> Result<Self> {
+        let tcp = TcpTransport::new(config, role)?;
 
         let config = match &config.noise {
             Some(v) => v.clone(),

--- a/src/transport/rustls.rs
+++ b/src/transport/rustls.rs
@@ -1,6 +1,6 @@
 use crate::config::{TlsConfig, TransportConfig};
 use crate::helper::host_port_pair;
-use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport};
+use crate::transport::{AddrMaybeCached, SocketOpts, TcpTransport, Transport, TransportRole};
 use std::fmt::Debug;
 use std::fs;
 use std::net::SocketAddr;
@@ -20,8 +20,12 @@ use p12::PFX;
 pub struct TlsTransport {
     tcp: TcpTransport,
     config: TlsConfig,
-    connector: Option<TlsConnector>,
-    tls_acceptor: Option<TlsAcceptor>,
+    endpoint: TlsEndpoint,
+}
+
+enum TlsEndpoint {
+    Client(TlsConnector),
+    Server(TlsAcceptor),
 }
 
 // workaround for TlsConnector and TlsAcceptor not implementing Debug
@@ -34,36 +38,31 @@ impl Debug for TlsTransport {
     }
 }
 
-fn load_server_config(config: &TlsConfig) -> Result<Option<ServerConfig>> {
-    if let Some(pkcs12_path) = config.pkcs12.as_ref() {
-        let pass = config
-            .pkcs12_password
-            .as_ref()
-            .context("Missing `tls.pkcs12_password`")?;
-        let buf = fs::read(pkcs12_path)?;
-        let pfx = PFX::parse(buf.as_slice())?;
+fn load_server_config(config: &TlsConfig) -> Result<ServerConfig> {
+    let pkcs12_path = config.pkcs12.as_ref().context("Missing `tls.pkcs12`")?;
+    let pass = config
+        .pkcs12_password
+        .as_ref()
+        .context("Missing `tls.pkcs12_password`")?;
+    let buf = fs::read(pkcs12_path).context("Failed to read `tls.pkcs12`")?;
+    let pfx = PFX::parse(buf.as_slice())?;
 
-        let certs = pfx.cert_bags(pass)?;
-        let keys = pfx.key_bags(pass)?;
+    let certs = pfx.cert_bags(pass)?;
+    let keys = pfx.key_bags(pass)?;
 
-        let chain: Vec<CertificateDer> = certs.into_iter().map(CertificateDer::from).collect();
-        let key = keys
-            .into_iter()
-            .next()
-            .map(PrivatePkcs8KeyDer::from)
-            .context("PKCS#12 identity contains no private key")?;
+    let chain: Vec<CertificateDer> = certs.into_iter().map(CertificateDer::from).collect();
+    let key = keys
+        .into_iter()
+        .next()
+        .map(PrivatePkcs8KeyDer::from)
+        .context("PKCS#12 identity contains no private key")?;
 
-        Ok(Some(
-            ServerConfig::builder()
-                .with_no_client_auth()
-                .with_single_cert(chain, key.into())?,
-        ))
-    } else {
-        Ok(None)
-    }
+    Ok(ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(chain, key.into())?)
 }
 
-fn load_client_config(config: &TlsConfig) -> Result<Option<ClientConfig>> {
+fn load_client_config(config: &TlsConfig) -> Result<ClientConfig> {
     let mut root_certs = RootCertStore::empty();
 
     if let Some(path) = config.trusted_root.as_deref() {
@@ -97,8 +96,7 @@ fn load_client_config(config: &TlsConfig) -> Result<Option<ClientConfig>> {
         }
 
         if native.certs.is_empty() {
-            // allow missing client root_certs (old behaviour)
-            return Ok(None);
+            anyhow::bail!("No trusted root certificates found in the system certificate store");
         }
 
         for cert in native.certs {
@@ -107,11 +105,9 @@ fn load_client_config(config: &TlsConfig) -> Result<Option<ClientConfig>> {
         }
     }
 
-    Ok(Some(
-        ClientConfig::builder()
-            .with_root_certificates(root_certs)
-            .with_no_client_auth(),
-    ))
+    Ok(ClientConfig::builder()
+        .with_root_certificates(root_certs)
+        .with_no_client_auth())
 }
 
 #[async_trait]
@@ -120,21 +116,26 @@ impl Transport for TlsTransport {
     type RawStream = TcpStream;
     type Stream = TlsStream<TcpStream>;
 
-    fn new(config: &TransportConfig) -> Result<Self> {
-        let tcp = TcpTransport::new(config)?;
+    fn new(config: &TransportConfig, role: TransportRole) -> Result<Self> {
+        let tcp = TcpTransport::new(config, role)?;
         let config = config
             .tls
             .as_ref()
             .ok_or_else(|| anyhow!("Missing tls config"))?;
 
-        let connector = load_client_config(config)?.map(|c| Arc::new(c).into());
-        let tls_acceptor = load_server_config(config)?.map(|c| Arc::new(c).into());
+        let endpoint = match role {
+            TransportRole::Client => {
+                TlsEndpoint::Client(Arc::new(load_client_config(config)?).into())
+            }
+            TransportRole::Server => {
+                TlsEndpoint::Server(Arc::new(load_server_config(config)?).into())
+            }
+        };
 
         Ok(TlsTransport {
             tcp,
             config: config.clone(),
-            connector,
-            tls_acceptor,
+            endpoint,
         })
     }
 
@@ -157,14 +158,31 @@ impl Transport for TlsTransport {
     }
 
     async fn handshake(&self, conn: Self::RawStream) -> Result<Self::Stream> {
-        let conn = self.tls_acceptor.as_ref().unwrap().accept(conn).await?;
+        let acceptor = match &self.endpoint {
+            TlsEndpoint::Server(acceptor) => acceptor,
+            TlsEndpoint::Client(_) => {
+                return Err(anyhow!(
+                    "Client TLS transport cannot perform a server handshake"
+                ));
+            }
+        };
+        let conn = acceptor
+            .accept(conn)
+            .await
+            .context("Failed to accept TLS connection")?;
         Ok(tokio_rustls::TlsStream::Server(conn))
     }
 
     async fn connect(&self, addr: &AddrMaybeCached) -> Result<Self::Stream> {
+        let connector = match &self.endpoint {
+            TlsEndpoint::Client(connector) => connector,
+            TlsEndpoint::Server(_) => {
+                return Err(anyhow!(
+                    "Server TLS transport cannot perform a client connection"
+                ));
+            }
+        };
         let conn = self.tcp.connect(addr).await?;
-
-        let connector = self.connector.as_ref().unwrap();
 
         let host_name = self
             .config
@@ -220,7 +238,10 @@ mod tests {
         let trusted_root = tempfile::NamedTempFile::new()?;
         fs::write(trusted_root.path(), b"not a PEM certificate")?;
 
-        let result = TlsTransport::new(&client_transport(trusted_root.path()));
+        let result = TlsTransport::new(
+            &client_transport(trusted_root.path()),
+            TransportRole::Client,
+        );
         assert!(result.is_err());
         Ok(())
     }
@@ -230,7 +251,10 @@ mod tests {
         let identity = tempfile::NamedTempFile::new()?;
         fs::write(identity.path(), b"not a PKCS#12 identity")?;
 
-        let result = TlsTransport::new(&server_transport(identity.path(), Some("password")));
+        let result = TlsTransport::new(
+            &server_transport(identity.path(), Some("password")),
+            TransportRole::Server,
+        );
         assert!(result.is_err());
         Ok(())
     }
@@ -238,7 +262,10 @@ mod tests {
     #[test]
     fn missing_identity_password_returns_error() -> Result<()> {
         let identity = tempfile::NamedTempFile::new()?;
-        let result = TlsTransport::new(&server_transport(identity.path(), None));
+        let result = TlsTransport::new(
+            &server_transport(identity.path(), None),
+            TransportRole::Server,
+        );
 
         let error = result.expect_err("missing PKCS#12 password should fail");
         assert!(error.to_string().contains("tls.pkcs12_password"));

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -3,7 +3,7 @@ use crate::{
     helper::tcp_connect_with_proxy,
 };
 
-use super::{AddrMaybeCached, SocketOpts, Transport};
+use super::{AddrMaybeCached, SocketOpts, Transport, TransportRole};
 use anyhow::Result;
 use async_trait::async_trait;
 use std::net::SocketAddr;
@@ -21,7 +21,7 @@ impl Transport for TcpTransport {
     type Stream = TcpStream;
     type RawStream = TcpStream;
 
-    fn new(config: &TransportConfig) -> Result<Self> {
+    fn new(config: &TransportConfig, _role: TransportRole) -> Result<Self> {
         Ok(TcpTransport {
             socket_opts: SocketOpts::from_cfg(&config.tcp),
             cfg: config.tcp.clone(),

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -4,9 +4,9 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
-use super::{AddrMaybeCached, SocketOpts, TcpTransport, TlsTransport, Transport};
+use super::{AddrMaybeCached, SocketOpts, TcpTransport, TlsTransport, Transport, TransportRole};
 use crate::config::TransportConfig;
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures_core::stream::Stream;
@@ -184,7 +184,7 @@ impl Transport for WebsocketTransport {
     type RawStream = TcpStream;
     type Stream = WebsocketTunnel;
 
-    fn new(config: &TransportConfig) -> anyhow::Result<Self> {
+    fn new(config: &TransportConfig, role: TransportRole) -> anyhow::Result<Self> {
         let wsconfig = config
             .websocket
             .as_ref()
@@ -195,8 +195,8 @@ impl Transport for WebsocketTransport {
             ..WebSocketConfig::default()
         };
         let sub = match wsconfig.tls {
-            true => SubTransport::Secure(TlsTransport::new(config)?),
-            false => SubTransport::Insecure(TcpTransport::new(config)?),
+            true => SubTransport::Secure(TlsTransport::new(config, role)?),
+            false => SubTransport::Insecure(TcpTransport::new(config, role)?),
         };
         Ok(WebsocketTransport { sub, conf })
     }
@@ -234,17 +234,63 @@ impl Transport for WebsocketTransport {
 
     async fn connect(&self, addr: &AddrMaybeCached) -> anyhow::Result<Self::Stream> {
         let u = format!("ws://{}", addr.addr.as_str());
-        let url = Url::parse(&u).unwrap();
+        let url = Url::parse(&u).with_context(|| format!("Invalid WebSocket URL `{u}`"))?;
         let tstream = match &self.sub {
             SubTransport::Insecure(t) => TransportStream::Insecure(t.connect(addr).await?),
             SubTransport::Secure(t) => TransportStream::Secure(Box::new(t.connect(addr).await?)),
         };
         let (wsstream, _) = client_async_with_config(url, tstream, Some(self.conf))
             .await
-            .expect("failed to connect");
+            .context("Failed to complete WebSocket client handshake")?;
         let tun = WebsocketTunnel {
             inner: StreamReader::new(StreamWrapper { inner: wsstream }),
         };
         Ok(tun)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{TlsConfig, TransportType, WebsocketConfig};
+    use std::fs;
+
+    fn secure_websocket_transport(tls: TlsConfig) -> TransportConfig {
+        TransportConfig {
+            transport_type: TransportType::Websocket,
+            tls: Some(tls),
+            websocket: Some(WebsocketConfig { tls: true }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn secure_websocket_server_without_identity_returns_error() {
+        let config = secure_websocket_transport(TlsConfig {
+            hostname: None,
+            trusted_root: None,
+            pkcs12: None,
+            pkcs12_password: None,
+        });
+
+        let error = WebsocketTransport::new(&config, TransportRole::Server)
+            .expect_err("missing server identity should fail during transport construction");
+        assert!(error.to_string().contains("tls.pkcs12"));
+    }
+
+    #[test]
+    fn secure_websocket_client_with_invalid_trust_returns_error() -> anyhow::Result<()> {
+        let trusted_root = tempfile::NamedTempFile::new()?;
+        fs::write(trusted_root.path(), b"not a PEM certificate")?;
+        let config = secure_websocket_transport(TlsConfig {
+            hostname: None,
+            trusted_root: Some(trusted_root.path().to_string_lossy().into_owned()),
+            pkcs12: None,
+            pkcs12_password: None,
+        });
+
+        WebsocketTransport::new(&config, TransportRole::Client)
+            .expect_err("invalid client trust should fail during transport construction");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- validate secure WebSockets with role-specific TLS requirements
- construct only the required client/server TLS endpoint and reject missing state during startup
- replace TLS and WebSocket panic paths with contextual errors
- cover invalid server identity and client trust with native-tls and rustls

## Validation
- cargo fmt and docs
- clippy with default and rustls CI features
- unit tests with default and rustls CI features
- all 134 supported feature combinations
- native-tls and rustls integration suites (7/7 each)

Closes #482