### PR TITLE
Implement TCP Fast Open (Linux only).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
  "futures-sink",
  "hex",
  "lazy_static",
+ "libc",
  "notify",
  "openssl",
  "p12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,9 @@ p12 = { version = "0.6.3", optional = true }
 [target.'cfg(target_env = "musl")'.dependencies]
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 vergen-gitcl = { version = "9.1.0", default-features = false, features = [
     "build",

--- a/README-zh.md
+++ b/README-zh.md
@@ -116,6 +116,7 @@ proxy = "socks5://user:passwd@127.0.0.1:1080" # Optional. The proxy used to conn
 nodelay = true # Optional. Override the `client.transport.nodelay` per service
 keepalive_secs = 20 # Optional. Specify `tcp_keepalive_time` in `tcp(7)`, if applicable. Default: 20 seconds
 keepalive_interval = 8 # Optional. Specify `tcp_keepalive_intvl` in `tcp(7)`, if applicable. Default: 8 seconds
+fast_open = false # Optional. Enable TCP Fast Open (`TCP_FASTOPEN`). Linux only; setting this to `true` on other platforms is a configuration error. Default: false
 
 [client.transport.tls] # Necessary if `type` is "tls"
 trusted_root = "ca.pem" # Necessary. The certificate of CA that signed the server's certificate

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ proxy = "socks5://user:passwd@127.0.0.1:1080" # Optional. The proxy used to conn
 nodelay = true # Optional. Determine whether to enable TCP_NODELAY, if applicable, to improve the latency but decrease the bandwidth. Default: true
 keepalive_secs = 20 # Optional. Specify `tcp_keepalive_time` in `tcp(7)`, if applicable. Default: 20 seconds
 keepalive_interval = 8 # Optional. Specify `tcp_keepalive_intvl` in `tcp(7)`, if applicable. Default: 8 seconds
+fast_open = false # Optional. Enable TCP Fast Open (`TCP_FASTOPEN`). Linux only; setting this to `true` on other platforms is a configuration error. Default: false
 
 [client.transport.tls] # Necessary if `type` is "tls"
 trusted_root = "ca.pem" # Necessary. The certificate of CA that signed the server's certificate

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,9 @@ use std::path::Path;
 use tokio::fs;
 use url::Url;
 
-use crate::transport::{DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_SECS, DEFAULT_NODELAY};
+use crate::transport::{
+    DEFAULT_FAST_OPEN, DEFAULT_KEEPALIVE_INTERVAL, DEFAULT_KEEPALIVE_SECS, DEFAULT_NODELAY,
+};
 
 /// Application-layer heartbeat interval in secs
 const DEFAULT_HEARTBEAT_INTERVAL_SECS: u64 = 30;
@@ -195,6 +197,10 @@ fn default_keepalive_interval() -> u64 {
     DEFAULT_KEEPALIVE_INTERVAL
 }
 
+fn default_fast_open() -> bool {
+    DEFAULT_FAST_OPEN
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct TcpConfig {
@@ -204,6 +210,8 @@ pub struct TcpConfig {
     pub keepalive_secs: u64,
     #[serde(default = "default_keepalive_interval")]
     pub keepalive_interval: u64,
+    #[serde(default = "default_fast_open")]
+    pub fast_open: bool,
     pub proxy: Option<Url>,
 }
 
@@ -213,6 +221,7 @@ impl Default for TcpConfig {
             nodelay: default_nodelay(),
             keepalive_secs: default_keepalive_secs(),
             keepalive_interval: default_keepalive_interval(),
+            fast_open: default_fast_open(),
             proxy: None,
         }
     }
@@ -342,6 +351,12 @@ impl Config {
                 "http" => Ok(()),
                 _ => Err(anyhow!(format!("Unknown proxy scheme: {}", u.scheme()))),
             })?;
+
+        #[cfg(not(target_os = "linux"))]
+        if config.tcp.fast_open {
+            return Err(anyhow!("`tcp.fast_open` is only supported on Linux"));
+        }
+
         match config.transport_type {
             TransportType::Tcp => Ok(()),
             TransportType::Tls => Config::validate_tls_config(config, is_server),

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -110,6 +110,7 @@ pub async fn udp_connect<A: ToSocketAddrs>(addr: A, prefer_ipv6: bool) -> Result
 pub async fn tcp_connect_with_proxy(
     addr: &AddrMaybeCached,
     proxy: Option<&Url>,
+    fast_open: bool,
 ) -> Result<TcpStream> {
     if let Some(url) = proxy {
         let addr = &addr.addr;
@@ -151,11 +152,77 @@ pub async fn tcp_connect_with_proxy(
         }
         Ok(s)
     } else {
+        #[cfg(target_os = "linux")]
+        if fast_open {
+            let socket_addr = match addr.socket_addr {
+                Some(s) => s,
+                None => to_socket_addr(&addr.addr).await?,
+            };
+            return tcp_connect_fast_open(socket_addr).await;
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = fast_open;
+        }
+
         Ok(match addr.socket_addr {
             Some(s) => TcpStream::connect(s).await?,
             None => TcpStream::connect(&addr.addr).await?,
         })
     }
+}
+
+#[cfg(target_os = "linux")]
+fn set_tcp_fastopen(
+    fd: std::os::unix::io::RawFd,
+    optname: libc::c_int,
+    value: libc::c_int,
+) -> Result<()> {
+    let ret = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_TCP,
+            optname,
+            &value as *const _ as *const libc::c_void,
+            std::mem::size_of::<libc::c_int>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+/// Create a TCP listener with `TCP_FASTOPEN` enabled. Linux only.
+#[cfg(target_os = "linux")]
+pub async fn tcp_bind_fast_open(addr: SocketAddr) -> Result<tokio::net::TcpListener> {
+    use std::os::unix::io::AsRawFd;
+
+    let socket = if addr.is_ipv4() {
+        tokio::net::TcpSocket::new_v4()?
+    } else {
+        tokio::net::TcpSocket::new_v6()?
+    };
+    socket.set_reuseaddr(true)?;
+    socket.bind(addr)?;
+    set_tcp_fastopen(socket.as_raw_fd(), libc::TCP_FASTOPEN, 1024)
+        .with_context(|| "Failed to set TCP_FASTOPEN")?;
+    Ok(socket.listen(1024)?)
+}
+
+/// Connect a TCP socket with `TCP_FASTOPEN_CONNECT` enabled. Linux only.
+#[cfg(target_os = "linux")]
+pub async fn tcp_connect_fast_open(addr: SocketAddr) -> Result<TcpStream> {
+    use std::os::unix::io::AsRawFd;
+
+    let socket = if addr.is_ipv4() {
+        tokio::net::TcpSocket::new_v4()?
+    } else {
+        tokio::net::TcpSocket::new_v6()?
+    };
+    set_tcp_fastopen(socket.as_raw_fd(), libc::TCP_FASTOPEN_CONNECT, 1)
+        .with_context(|| "Failed to set TCP_FASTOPEN_CONNECT")?;
+    Ok(socket.connect(addr).await?)
 }
 
 // Wrapper of retry_notify

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -14,6 +14,8 @@ pub const DEFAULT_NODELAY: bool = true;
 pub const DEFAULT_KEEPALIVE_SECS: u64 = 20;
 pub const DEFAULT_KEEPALIVE_INTERVAL: u64 = 8;
 
+pub const DEFAULT_FAST_OPEN: bool = false;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransportRole {
     Client,

--- a/src/transport/native_tls.rs
+++ b/src/transport/native_tls.rs
@@ -86,10 +86,10 @@ impl Transport for TlsTransport {
     }
 
     async fn bind<A: ToSocketAddrs + Send + Sync>(&self, addr: A) -> Result<Self::Acceptor> {
-        let l = TcpListener::bind(addr)
+        self.tcp
+            .bind(addr)
             .await
-            .with_context(|| "Failed to create tcp listener")?;
-        Ok(l)
+            .with_context(|| "Failed to create tcp listener")
     }
 
     async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::RawStream, SocketAddr)> {

--- a/src/transport/noise.rs
+++ b/src/transport/noise.rs
@@ -75,7 +75,7 @@ impl Transport for NoiseTransport {
     }
 
     async fn bind<T: ToSocketAddrs + Send + Sync>(&self, addr: T) -> Result<Self::Acceptor> {
-        Ok(TcpListener::bind(addr).await?)
+        self.tcp.bind(addr).await
     }
 
     async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::RawStream, SocketAddr)> {

--- a/src/transport/rustls.rs
+++ b/src/transport/rustls.rs
@@ -144,10 +144,10 @@ impl Transport for TlsTransport {
     }
 
     async fn bind<A: ToSocketAddrs + Send + Sync>(&self, addr: A) -> Result<Self::Acceptor> {
-        let l = TcpListener::bind(addr)
+        self.tcp
+            .bind(addr)
             .await
-            .with_context(|| "Failed to create tcp listener")?;
-        Ok(l)
+            .with_context(|| "Failed to create tcp listener")
     }
 
     async fn accept(&self, a: &Self::Acceptor) -> Result<(Self::RawStream, SocketAddr)> {

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -2,6 +2,8 @@ use crate::{
     config::{TcpConfig, TransportConfig},
     helper::tcp_connect_with_proxy,
 };
+#[cfg(target_os = "linux")]
+use crate::helper::{tcp_bind_fast_open, to_socket_addr};
 
 use super::{AddrMaybeCached, SocketOpts, Transport, TransportRole};
 use anyhow::Result;
@@ -33,6 +35,11 @@ impl Transport for TcpTransport {
     }
 
     async fn bind<T: ToSocketAddrs + Send + Sync>(&self, addr: T) -> Result<Self::Acceptor> {
+        #[cfg(target_os = "linux")]
+        if self.cfg.fast_open {
+            let socket_addr = to_socket_addr(addr).await?;
+            return tcp_bind_fast_open(socket_addr).await;
+        }
         Ok(TcpListener::bind(addr).await?)
     }
 
@@ -47,7 +54,7 @@ impl Transport for TcpTransport {
     }
 
     async fn connect(&self, addr: &AddrMaybeCached) -> Result<Self::Stream> {
-        let s = tcp_connect_with_proxy(addr, self.cfg.proxy.as_ref()).await?;
+        let s = tcp_connect_with_proxy(addr, self.cfg.proxy.as_ref(), self.cfg.fast_open).await?;
         self.socket_opts.apply(&s);
         Ok(s)
     }

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -1,9 +1,9 @@
+#[cfg(target_os = "linux")]
+use crate::helper::{tcp_bind_fast_open, to_socket_addr};
 use crate::{
     config::{TcpConfig, TransportConfig},
     helper::tcp_connect_with_proxy,
 };
-#[cfg(target_os = "linux")]
-use crate::helper::{tcp_bind_fast_open, to_socket_addr};
 
 use super::{AddrMaybeCached, SocketOpts, Transport, TransportRole};
 use anyhow::Result;

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -209,7 +209,10 @@ impl Transport for WebsocketTransport {
         &self,
         addr: A,
     ) -> anyhow::Result<Self::Acceptor> {
-        TcpListener::bind(addr).await.map_err(Into::into)
+        match &self.sub {
+            SubTransport::Insecure(t) => t.bind(addr).await,
+            SubTransport::Secure(t) => t.bind(addr).await,
+        }
     }
 
     async fn accept(&self, a: &Self::Acceptor) -> anyhow::Result<(Self::RawStream, SocketAddr)> {


### PR DESCRIPTION
Adds an optional `tcp.fast_open` config field (default `false`) that enables `TCP_FASTOPEN` on the server listener and `TCP_FASTOPEN_CONNECT` on the client connect path, using raw `setsockopt` calls via the `libc` crate.

Scoped to Linux only. `socket2` (the crate already used for other socket options) has no TFO support in any version, and cross-platform client-side TFO would require unsafe, OS-specific syscalls (`connectx` on macOS, `ConnectEx` on Windows) that bypass tokio's normal connect path. Setting `fast_open = true` on a non-Linux target is rejected at config-validation time.

Changes:
- `Cargo.toml`: add `libc` as a Linux-only dependency
- `src/helper.rs`: new `tcp_bind_fast_open` / `tcp_connect_fast_open` helpers built on `tokio::net::TcpSocket`, which already implements the async connect/listen semantics needed once the sockopt is set
- `src/config.rs`: new `TcpConfig.fast_open` field, plus a platform check in `validate_transport_config`
- `src/transport/tcp.rs`: wires `fast_open` into `bind()`/`connect()`
- `src/transport/rustls.rs`, `native_tls.rs`, `noise.rs`, `websocket.rs`: `bind()` now delegates to the shared `TcpTransport`, so the fast-open listener path applies to every transport instead of only plain TCP
- `README.md` / `README-zh.md`: document the new option

Verified: `cargo build` (default and `--no-default-features --features embedded`), `cargo test`, and a manual client/server smoke test with `fast_open = true` on both sides confirming forwarding still works end to end.