### PR TITLE
Add nix flake support.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787204541,
+        "narHash": "sha256-OURZPknrTjQrlNyxPdqzyqmU/81Wes1CUP/Ft1Rv/YI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5880666fd9eb563038431edb35c2d0aa595884e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-26.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,82 @@
+{
+  description = "A lightweight and high-performance reverse proxy for NAT traversal";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      overlays.default = final: prev: {
+        rathole = final.rustPlatform.buildRustPackage {
+          pname = "rathole";
+          version = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package.version;
+          src = final.lib.fileset.toSource {
+            root = ./.;
+            fileset = final.lib.fileset.unions [
+              ./src
+              ./build.rs
+              ./Cargo.toml
+              ./Cargo.lock
+            ];
+          };
+          cargoLock.lockFile = ./Cargo.lock;
+          nativeBuildInputs = [ final.pkg-config ];
+          buildInputs = [ final.zlib ] ++ final.lib.optionals final.stdenv.isLinux [ final.openssl ];
+          doCheck = false;
+          meta = {
+            description = "A lightweight and high-performance reverse proxy for NAT traversal";
+            homepage = "https://github.com/rathole-org/rathole";
+            license = final.lib.licenses.asl20;
+            mainProgram = "rathole";
+          };
+        };
+      };
+
+      packages = forAllSystems (
+        pkgs:
+        let
+          pkgs' = pkgs.extend self.overlays.default;
+        in
+        {
+          rathole = pkgs'.rathole;
+          default = pkgs'.rathole;
+        }
+      );
+
+      apps = forAllSystems (pkgs: rec {
+        rathole = {
+          type = "app";
+          program = pkgs.lib.getExe self.packages.${pkgs.stdenv.hostPlatform.system}.rathole;
+        };
+        default = rathole;
+      });
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          inputsFrom = [ self.packages.${pkgs.stdenv.hostPlatform.system}.rathole ];
+          packages = with pkgs; [
+            rustfmt
+            clippy
+            rust-analyzer
+          ];
+        };
+      });
+
+      checks = forAllSystems (pkgs: {
+        rathole = self.packages.${pkgs.stdenv.hostPlatform.system}.rathole;
+      });
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-tree);
+    };
+}


### PR DESCRIPTION
Adds a flake.nix (with pinned flake.lock) so the project can be built, run, and developed with Nix directly from the repository: nix build, nix run github:rathole-org/rathole, and nix develop for a dev shell with the full build environment plus rustfmt/clippy/rust-analyzer. Also exposes overlays.default for NixOS/nix-darwin users, checks for nix flake check, and a formatter for nix fmt.

The only input is nixpkgs (pinned to the current stable release, nixos-26.05), following the zero-framework-dependency style used by projects like helix and jj — no flake-utils/crane. zlib is provided via pkg-config because vergen's git feature pulls in libz-sys, whose vendored zlib fails to compile with newer clang on darwin (nixpkgs' own rathole package works around the same issue by patching out vergen; providing zlib avoids carrying a patch here). openssl is added on Linux for native-tls. The source is filtered with lib.fileset to src/, build.rs, Cargo.toml, and Cargo.lock so docs-only changes don't trigger rebuilds, and doCheck = false since the integration tests bind loopback ports and rely on real timing, which is unreliable inside the Nix build sandbox.

Changes:
- flake.nix: package built with rustPlatform.buildRustPackage reusing the repository's Cargo.lock, version read from Cargo.toml; outputs packages, apps, devShells, overlays.default, checks, and formatter for the four common systems
- flake.lock: pins nixpkgs to nixos-26.05

Verified: nix flake check and nix build on aarch64-darwin (all default features enabled), plus a manual client/server smoke test with the Nix-built binary forwarding a local HTTP service end to end.