### PR TITLE
Strengthen UDP tests with varied packet lengths, more rounds and concurrency.

### DIFF
--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,7 @@
 use anyhow::{Ok, Result};
 use common::{run_rathole_client, PING, PONG};
 use rand::Rng;
+use rathole::UDP_BUFFER_SIZE;
 use std::time::Duration;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -19,7 +20,9 @@ const ECHO_SERVER_ADDR: &str = "127.0.0.1:8080";
 const PINGPONG_SERVER_ADDR: &str = "127.0.0.1:8081";
 const ECHO_SERVER_ADDR_EXPOSED: &str = "127.0.0.1:2334";
 const PINGPONG_SERVER_ADDR_EXPOSED: &str = "127.0.0.1:2335";
-const HITTER_NUM: usize = 4;
+const TCP_HITTER_NUM: usize = 4;
+const UDP_HITTER_NUM: usize = 8;
+const UDP_ROUNDS: usize = 50;
 
 #[derive(Clone, Copy, Debug)]
 enum Type {
@@ -193,9 +196,14 @@ async fn test(config_path: &'static str, t: Type) -> Result<()> {
     // Simulate heavy load
     info!("lots of echo and pingpong");
 
+    let hitter_num = match t {
+        Type::Tcp => TCP_HITTER_NUM,
+        Type::Udp => UDP_HITTER_NUM,
+    };
+
     let mut v = Vec::new();
 
-    for _ in 0..HITTER_NUM / 2 {
+    for _ in 0..hitter_num / 2 {
         v.push(tokio::spawn(async move {
             echo_hitter(ECHO_SERVER_ADDR_EXPOSED, t).await.unwrap();
         }));
@@ -254,18 +262,19 @@ async fn udp_echo_hitter(addr: &'static str) -> Result<()> {
     let conn = UdpSocket::bind("127.0.0.1:0").await?;
     conn.connect(addr).await?;
 
-    let mut wr = [0u8; 128];
-    let mut rd = [0u8; 128];
-    for _ in 0..3 {
-        rand::thread_rng().fill(&mut wr);
+    let mut wr = [0u8; UDP_BUFFER_SIZE];
+    let mut rd = [0u8; UDP_BUFFER_SIZE];
+    for _ in 0..UDP_ROUNDS {
+        let len = rand::thread_rng().gen_range(1..=UDP_BUFFER_SIZE);
+        rand::thread_rng().fill(&mut wr[..len]);
 
-        conn.send(&wr).await?;
-        debug!("send");
+        conn.send(&wr[..len]).await?;
+        debug!("send {} bytes", len);
 
-        conn.recv(&mut rd).await?;
-        debug!("recv");
+        let n = conn.recv(&mut rd).await?;
+        debug!("recv {} bytes", n);
 
-        assert_eq!(wr, rd);
+        assert_eq!(wr[..len], rd[..n]);
     }
     Ok(())
 }
@@ -292,7 +301,7 @@ async fn udp_pingpong_hitter(addr: &'static str) -> Result<()> {
     let wr = PING.as_bytes();
     let mut rd = [0u8; PONG.len()];
 
-    for _ in 0..3 {
+    for _ in 0..UDP_ROUNDS {
         conn.send(wr).await?;
         debug!("ping");
 


### PR DESCRIPTION
Strengthens the UDP integration tests as requested in #80. UDP echo packets now vary in length instead of being fixed at 128 bytes: each round sends a random payload of 1..=`UDP_BUFFER_SIZE` (2048) bytes and asserts both the received length and content. Echo/pingpong rounds are increased from 3 to 50 for longer duration, and the heavy-load phase now runs 8 concurrent UDP hitters (TCP keeps its 4).

Effectiveness was verified by mutation testing: with an artificial bug seeded into the server's UDP forwarding path (truncating forwarded payloads to 256 bytes in `src/server.rs`), the old tests still pass — their fixed 128-byte packets never exercise the truncation — while the strengthened tests catch it in under 4 seconds. Against the unmodified source the suite passes reliably, so the added randomness and concurrency don't introduce flakiness.

Changes:
- `tests/integration_test.rs`: random per-round payload lengths up to `UDP_BUFFER_SIZE` with length and content assertions, `UDP_ROUNDS = 50` (was 3), per-type hitter counts for the heavy-load phase (UDP 8, TCP unchanged at 4)

Verified: `cargo test --test integration_test udp` passes on macOS with default features (tcp, noise, and websocket transports), and the same suite fails within seconds against the seeded payload-truncation bug that the previous tests could not detect.

Note: CI on `main` currently fails for any PR due to pre-existing issues unrelated to this change (expired self-signed TLS test certificates in `examples/tls/`, and `cargo install cargo-hack` no longer working on the pinned 1.71.0 toolchain).

Closes #80.