### PR TITLE
docs: fix typo writting -> writing

### DIFF
--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -63,4 +63,4 @@ strip rathole
 upx --best --lzma rathole
 ```
 
-At the time of writting the build guide, the produced binary for `x86_64-unknown-linux-glibc` has the size of **574 KiB**, while `frpc` has the size of **~10 MiB**, which is much larger.
+At the time of writing the build guide, the produced binary for `x86_64-unknown-linux-glibc` has the size of **574 KiB**, while `frpc` has the size of **~10 MiB**, which is much larger.


### PR DESCRIPTION
Corrects the misspelling `writting` -> `writing` in `docs/build-guide.md`.

Documentation only, no behaviour change.